### PR TITLE
.github: Fix link to CONTRIBUTING.md in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 
 <!-- Please ensure you've completed the following steps by replacing [ ] with [x]-->
 
-- [ ] I have read the [Contributing Guidelines](../../CONTRIBUTING.md) for this project.
+- [ ] I have read the [Contributing Guidelines](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md) for this project.
 - [ ] I have searched the issue tracker for an issue that matches the one I want to file, without success.
 
 ### Issue Details


### PR DESCRIPTION
The existing relative link won’t work, as it’s eventually resolved
relative to
`github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/123`
rather than to the `.github/workflows` directory in git, as I suspect
was intended.

The relative link `../blob/trunk/CONTRIBUTING.md` does work when
resolved relative to the issue URI, but is fairly unintelligible by
someone when they’re previewing an issue or reading the Markdown while
filling in the template.

So I think it makes most sense to use the full URI to `CONTRIBUTING.md`,
which will work in all situations.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

See commit message above.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

© 2021 ThoughtWorks, Inc.
