### PR TITLE
core: Add USW2-RDS:ChargedBackupUsage to types list

### DIFF
--- a/packages/core/src/services/aws/RDSStorage.ts
+++ b/packages/core/src/services/aws/RDSStorage.ts
@@ -77,7 +77,11 @@ export default class RDSStorage implements ICloudService {
       awsGroupKey.endsWith('PIOPS-Storage')
     )
       return DiskType.SSD
-    if (awsGroupKey.endsWith('StorageUsage')) return DiskType.HDD
+    if (
+      awsGroupKey.endsWith('StorageUsage') ||
+      awsGroupKey.endsWith('RDS:ChargedBackupUsage')
+    )
+      return DiskType.HDD
     this.rdsStorageLogger.warn(
       'Unexpected Cost explorer Dimension Name: ' + awsGroupKey,
     )


### PR DESCRIPTION
Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

## Description of Change

Adds a missing suffix check for `RDS:ChargedBackupUsage` to set it as using a HDD. This fixes the warning:
```
api_1     | 2021-05-25T10:03:01.861Z [RDS Storage Logger] warn: Unexpected Cost explorer Dimension Name: USW2-RDS:ChargedBackupUsage 
```

## Checklist

- [x] PR description included and stakeholders cc'd