### PR TITLE
[487] Rename ComputeUsage.numberOfvCpus

### DIFF
--- a/packages/aws/src/__tests__/EC2.test.ts
+++ b/packages/aws/src/__tests__/EC2.test.ts
@@ -139,7 +139,7 @@ describe('EC2', () => {
     expect(result).toEqual([
       {
         cpuUtilizationAverage: (22.983333333333334 + 11.566666666666666) / 2, //should be the average of CPUUtilization accross vcpus per hour
-        numberOfvCpus: 4,
+        vCpuHours: 4,
         timestamp: new Date(dayOneHourOne),
         usesAverageCPUConstant: false,
       },
@@ -147,13 +147,13 @@ describe('EC2', () => {
         cpuUtilizationAverage:
           (31.435897435897434 + 11.576923076923077 + 9.63265306122449 + 24.25) /
           4,
-        numberOfvCpus: 4.5,
+        vCpuHours: 4.5,
         timestamp: new Date(dayOneHourTwo),
         usesAverageCPUConstant: false,
       },
       {
         cpuUtilizationAverage: (9.716666666666667 + 13.083333333333334) / 2,
-        numberOfvCpus: 4,
+        vCpuHours: 4,
         timestamp: new Date(dayTwoHourOne),
         usesAverageCPUConstant: false,
       },
@@ -161,7 +161,7 @@ describe('EC2', () => {
         cpuUtilizationAverage:
           (20.46153846153846 + 32.44444444444444 + 10.26923076923077 + 9.75) /
           4,
-        numberOfvCpus: 4.333333333333333,
+        vCpuHours: 4.333333333333333,
         timestamp: new Date(dayTwoHourTwo),
         usesAverageCPUConstant: false,
       },
@@ -253,13 +253,13 @@ describe('EC2', () => {
       expect(result).toEqual([
         {
           cpuUtilizationAverage: 1,
-          numberOfvCpus: 1,
+          vCpuHours: 1,
           timestamp: new Date(dayOneHourOne),
           usesAverageCPUConstant: false,
         },
         {
           cpuUtilizationAverage: AVG_CPU_UTILIZATION_2020,
-          numberOfvCpus: 1,
+          vCpuHours: 1,
           timestamp: new Date(dayOneHourTwo),
           usesAverageCPUConstant: true,
         },
@@ -293,13 +293,13 @@ describe('EC2', () => {
       expect(result).toEqual([
         {
           cpuUtilizationAverage: AVG_CPU_UTILIZATION_2020,
-          numberOfvCpus: 4,
+          vCpuHours: 4,
           timestamp: new Date(dayOneHourOne),
           usesAverageCPUConstant: true,
         },
         {
           cpuUtilizationAverage: AVG_CPU_UTILIZATION_2020,
-          numberOfvCpus: 3,
+          vCpuHours: 3,
           timestamp: new Date(dayOneHourTwo),
           usesAverageCPUConstant: true,
         },
@@ -344,7 +344,7 @@ describe('EC2', () => {
     expect(result).toEqual([
       {
         cpuUtilizationAverage: 1,
-        numberOfvCpus: 1,
+        vCpuHours: 1,
         timestamp: new Date(dayTwoHourTwo),
         usesAverageCPUConstant: false,
       },

--- a/packages/aws/src/__tests__/ElastiCache.test.ts
+++ b/packages/aws/src/__tests__/ElastiCache.test.ts
@@ -120,13 +120,13 @@ describe('ElastiCache', () => {
     expect(usageByHour).toEqual([
       {
         cpuUtilizationAverage: 1.0456,
-        numberOfvCpus: 4,
+        vCpuHours: 4,
         timestamp: new Date(startDate),
         usesAverageCPUConstant: false,
       },
       {
         cpuUtilizationAverage: 2.03242,
-        numberOfvCpus: 4,
+        vCpuHours: 4,
         timestamp: new Date(dayTwo),
         usesAverageCPUConstant: false,
       },
@@ -242,7 +242,7 @@ describe('ElastiCache', () => {
     expect(usageByHour).toEqual([
       {
         cpuUtilizationAverage: 50,
-        numberOfvCpus: 2,
+        vCpuHours: 2,
         timestamp: new Date(startDate),
         usesAverageCPUConstant: true,
       },
@@ -318,7 +318,7 @@ describe('ElastiCache', () => {
     expect(usageByHour).toEqual([
       {
         cpuUtilizationAverage: 50,
-        numberOfvCpus: 8,
+        vCpuHours: 8,
         timestamp: new Date(startDate),
         usesAverageCPUConstant: false,
       },
@@ -396,7 +396,7 @@ describe('ElastiCache', () => {
     expect(usageByHour).toEqual([
       {
         cpuUtilizationAverage: 60,
-        numberOfvCpus: 6,
+        vCpuHours: 6,
         timestamp: new Date(startDate),
         usesAverageCPUConstant: false,
       },

--- a/packages/aws/src/__tests__/RDSCompute.test.ts
+++ b/packages/aws/src/__tests__/RDSCompute.test.ts
@@ -103,13 +103,13 @@ describe('RDS Compute', function () {
     expect(usageByHour).toEqual([
       {
         cpuUtilizationAverage: 32.34,
-        numberOfvCpus: 2,
+        vCpuHours: 2,
         timestamp: new Date('2020-01-25T00:00:00.000Z'),
         usesAverageCPUConstant: false,
       },
       {
         cpuUtilizationAverage: 12.65,
-        numberOfvCpus: 96,
+        vCpuHours: 96,
         timestamp: new Date('2020-01-26T00:00:00.000Z'),
         usesAverageCPUConstant: false,
       },
@@ -175,13 +175,13 @@ describe('RDS Compute', function () {
     expect(usageByHour).toEqual([
       {
         cpuUtilizationAverage: 32.34,
-        numberOfvCpus: 2,
+        vCpuHours: 2,
         timestamp: new Date('2020-01-25T00:00:00.000Z'),
         usesAverageCPUConstant: false,
       },
       {
         cpuUtilizationAverage: AWS_CLOUD_CONSTANTS.AVG_CPU_UTILIZATION_2020,
-        numberOfvCpus: 96,
+        vCpuHours: 96,
         timestamp: new Date('2020-01-26T00:00:00.000Z'),
         usesAverageCPUConstant: true,
       },

--- a/packages/aws/src/lib/AWSComputeEstimatesBuilder.ts
+++ b/packages/aws/src/lib/AWSComputeEstimatesBuilder.ts
@@ -44,7 +44,7 @@ export default class AWSComputeEstimatesBuilder extends FootprintEstimatesDataBu
   private getComputeUsage(): ComputeUsage {
     return {
       cpuUtilizationAverage: AWS_CLOUD_CONSTANTS.AVG_CPU_UTILIZATION_2020,
-      numberOfvCpus: this.vCpuHours,
+      vCpuHours: this.vCpuHours,
       usesAverageCPUConstant: true,
     }
   }

--- a/packages/azure/src/lib/ConsumptionManagement.ts
+++ b/packages/azure/src/lib/ConsumptionManagement.ts
@@ -411,7 +411,7 @@ export default class ConsumptionManagementService {
     const computeUsage: ComputeUsage = {
       timestamp: consumptionDetailRow.timestamp,
       cpuUtilizationAverage: AZURE_CLOUD_CONSTANTS.AVG_CPU_UTILIZATION_2020,
-      numberOfvCpus: consumptionDetailRow.vCpuHours,
+      vCpuHours: consumptionDetailRow.vCpuHours,
       usesAverageCPUConstant: true,
     }
 

--- a/packages/core/src/compute/ComputeEstimator.ts
+++ b/packages/core/src/compute/ComputeEstimator.ts
@@ -39,7 +39,7 @@ export default class ComputeEstimator implements IFootprintEstimator {
     return data.map((usage) => {
       const estimatedKilowattHours = ENERGY_ESTIMATION_FORMULA(
         usage.cpuUtilizationAverage,
-        usage.numberOfvCpus,
+        usage.vCpuHours,
         constants.minWatts,
         constants.maxWatts,
         constants.powerUsageEffectiveness,

--- a/packages/core/src/compute/ComputeUsage.ts
+++ b/packages/core/src/compute/ComputeUsage.ts
@@ -7,20 +7,20 @@ import { IUsageData, CloudConstants } from '../.'
 
 export default interface ComputeUsage extends IUsageData {
   cpuUtilizationAverage: number
-  numberOfvCpus: number
+  vCpuHours: number
   usesAverageCPUConstant: boolean
 }
 
 export class ComputeUsageBuilder {
   private timestamp: string
   private cpuUtilizations: number[]
-  private numberOfvCpus: number
+  private vCpuHours: number
   private constants: CloudConstants
 
   constructor(timestamp: string, constants: CloudConstants) {
     this.timestamp = timestamp
     this.cpuUtilizations = []
-    this.numberOfvCpus = 0
+    this.vCpuHours = 0
     this.constants = constants
   }
 
@@ -31,8 +31,8 @@ export class ComputeUsageBuilder {
     return this
   }
 
-  setNumberOfvCpus(numberOfvCpus: number): ComputeUsageBuilder {
-    this.numberOfvCpus = numberOfvCpus
+  setVCpuHours(vCpuHours: number): ComputeUsageBuilder {
+    this.vCpuHours = vCpuHours
     return this
   }
 
@@ -45,7 +45,7 @@ export class ComputeUsageBuilder {
     return {
       timestamp: new Date(this.timestamp),
       cpuUtilizationAverage,
-      numberOfvCpus: this.numberOfvCpus,
+      vCpuHours: this.vCpuHours,
       usesAverageCPUConstant: !hasMeasurements,
     }
   }
@@ -78,7 +78,7 @@ const mergeUsageByTimestamp = (
   if (data.id === 'cpuUtilization') {
     acc[data.timestamp] = usageToUpdate.addCpuUtilization(data.value)
   } else if (data.id === 'vCPUs') {
-    acc[data.timestamp] = usageToUpdate.setNumberOfvCpus(data.value)
+    acc[data.timestamp] = usageToUpdate.setVCpuHours(data.value)
   }
   return acc
 }
@@ -93,5 +93,5 @@ export function buildComputeUsages(
   )
   return Object.values(groupedComputeUsages)
     .map((builder: ComputeUsageBuilder) => builder.build())
-    .filter((usage: ComputeUsage) => usage.numberOfvCpus > 0)
+    .filter((usage: ComputeUsage) => usage.vCpuHours > 0)
 }

--- a/packages/core/src/compute/__tests__/ComputeEstimator.test.ts
+++ b/packages/core/src/compute/__tests__/ComputeEstimator.test.ts
@@ -11,7 +11,7 @@ describe('ComputeEstimator', () => {
       {
         timestamp: new Date('2020-01-01'),
         cpuUtilizationAverage: 1.0,
-        numberOfvCpus: 1.0,
+        vCpuHours: 1.0,
         usesAverageCPUConstant: false,
       },
     ]
@@ -47,7 +47,7 @@ describe('ComputeEstimator', () => {
       {
         timestamp: new Date('2020-01-01'),
         cpuUtilizationAverage: 1.0,
-        numberOfvCpus: 1.0,
+        vCpuHours: 1.0,
         usesAverageCPUConstant: false,
       },
     ]

--- a/packages/core/src/compute/__tests__/ComputeUsage.test.ts
+++ b/packages/core/src/compute/__tests__/ComputeUsage.test.ts
@@ -88,19 +88,19 @@ describe('ComputeUsage', () => {
     const expectedResult: ComputeUsage[] = [
       {
         cpuUtilizationAverage: 19.22386839351125,
-        numberOfvCpus: 4.5,
+        vCpuHours: 4.5,
         timestamp: new Date(dayOneHourOne),
         usesAverageCPUConstant: false,
       },
       {
         cpuUtilizationAverage: 11.4,
-        numberOfvCpus: 4,
+        vCpuHours: 4,
         timestamp: new Date(dayTwoHourOne),
         usesAverageCPUConstant: false,
       },
       {
         cpuUtilizationAverage: 18.231303418803417,
-        numberOfvCpus: 4.333333333333333,
+        vCpuHours: 4.333333333333333,
         timestamp: new Date(dayTwoHourTwo),
         usesAverageCPUConstant: false,
       },
@@ -123,7 +123,7 @@ describe('ComputeUsage', () => {
     const expectedResults = [
       {
         cpuUtilizationAverage: 50,
-        numberOfvCpus: 4.5,
+        vCpuHours: 4.5,
         timestamp: new Date(dayOneHourOne),
         usesAverageCPUConstant: true,
       },

--- a/packages/gcp/src/__tests__/ComputeEngine.test.ts
+++ b/packages/gcp/src/__tests__/ComputeEngine.test.ts
@@ -175,13 +175,13 @@ describe('ComputeEngine', () => {
     expect(result).toEqual([
       {
         cpuUtilizationAverage: 0.25,
-        numberOfvCpus: 4,
+        vCpuHours: 4,
         timestamp: dayOneHourOne,
         usesAverageCPUConstant: false,
       },
       {
         cpuUtilizationAverage: 0.75,
-        numberOfvCpus: 2,
+        vCpuHours: 2,
         timestamp: dayOneHourTwo,
         usesAverageCPUConstant: false,
       },
@@ -241,14 +241,14 @@ describe('ComputeEngine', () => {
     expect(result).toEqual([
       {
         cpuUtilizationAverage: 0.25,
-        numberOfvCpus: 4,
+        vCpuHours: 4,
         timestamp: dayOneHourOne,
         usesAverageCPUConstant: false,
       },
       {
         cpuUtilizationAverage:
           GCP_CLOUD_CONSTANTS.AVG_CPU_UTILIZATION_2020 / 100,
-        numberOfvCpus: 2,
+        vCpuHours: 2,
         timestamp: dayOneHourTwo,
         usesAverageCPUConstant: true,
       },

--- a/packages/gcp/src/lib/BillingExportTable.ts
+++ b/packages/gcp/src/lib/BillingExportTable.ts
@@ -242,7 +242,7 @@ export default class BillingExportTable {
   ): FootprintEstimate {
     const computeUsage: ComputeUsage = {
       cpuUtilizationAverage: GCP_CLOUD_CONSTANTS.AVG_CPU_UTILIZATION_2020,
-      numberOfvCpus: usageRow.vCpuHours,
+      vCpuHours: usageRow.vCpuHours,
       usesAverageCPUConstant: true,
       timestamp,
     }

--- a/packages/gcp/src/lib/ComputeEngine.ts
+++ b/packages/gcp/src/lib/ComputeEngine.ts
@@ -74,7 +74,7 @@ export default class ComputeEngine extends ServiceWithCPUUtilization {
       )
       result.push({
         cpuUtilizationAverage: cpuUtilizationAverage,
-        numberOfvCpus: point.value.doubleValue,
+        vCpuHours: point.value.doubleValue,
         timestamp: new Date(+point.interval.startTime.seconds * 1000),
         usesAverageCPUConstant: !measuredCpuUtilization,
       })

--- a/packages/gcp/src/lib/Recommendations.ts
+++ b/packages/gcp/src/lib/Recommendations.ts
@@ -444,7 +444,7 @@ export default class Recommendations implements ICloudRecommendationsService {
 
     const computeUsage = {
       cpuUtilizationAverage: GCP_CLOUD_CONSTANTS.AVG_CPU_UTILIZATION_2020,
-      numberOfvCpus: vCpuHours,
+      vCpuHours: vCpuHours,
       usesAverageCPUConstant: true,
     }
 


### PR DESCRIPTION
The value it represents is actually vCPU hours - rename to reflect this.

## Description of Change

Rename the field to better reflect its value.

## Checklist

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)

## Notes

Fix for issue https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/487
