### PR TITLE
Add gitpod for setting up an dev/demo in browser

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,4 +14,3 @@ ports:
   # set this to open-preview, if you want to be able to browse to API endpoints
   - port: 4000
     onOpen: ignore
-git

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,17 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: |
+      yarn install
+      yarn test
+    # obviously don't do this in prod
+    # this allows us to spin up a demo with mock data
+    command: DANGEROUSLY_DISABLE_HOST_CHECK=true yarn start-with-mock-data
+
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 3000
+    onOpen: open-preview
+  # set this to open-preview, if you want to be able to browse to API endpoints
+  - port: 4000
+    onOpen: ignore
+git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,18 @@ Feel free to post a comment in the pull request to ping reviewers if you are awa
 
 ---
 
+### Documentation
+
+To add contribute to the documentation, make sure you are in the `microsite` directory, then run the commands below.
+
+```
+yarn install # install the dependencies
+yarn start   # start a running instance of docusaurus 
+```
+
+This will start a live-updating server show that will show any change you make the markdown files in `microsite/docs/`  as soon as they are saved.
+
+
 ## Bundle size analysis 🔍
 
 From the client folder

--- a/microsite/docs/GettingStarted.md
+++ b/microsite/docs/GettingStarted.md
@@ -3,14 +3,17 @@ id: getting-started
 title: Getting Started
 ---
 
-There are two different ways to get started with Cloud Carbon Footprint:
+There are three different ways to get started with Cloud Carbon Footprint:
 
 - Create a standalone app using the command line interface
 - Clone the Cloud Carbon Footprint repository
+- Run Cloud Carbon Footprint in an ephemeral workspace with a hosted development environment provider
 
 For the best way of staying up to date with the project, you can create a standalone app for simple customization according to your needs. This method uses the @cloud-carbon-footprint packages as npm dependencies, making for a more lightweight standalone app.
 
 Forking and cloning the repository is the best way to contribute to the project. Cloning the project will include all of the @cloud-carbon-footprint packages for local development and configuration. This path offers the option to create Pull Requests and to stay up to date with the latest changes.
+
+If you want to run project in a disposable development environment to see how Cloud Carbon Footprint works, and make changes, you can spin up an environment with Gitpod, a hosted service. This will be running a development environment on _their_ infrastructure - bear this in mind when testing it out with any cloud provider credentials.
 
 ### Prerequisites
 
@@ -98,3 +101,30 @@ Note:
 - During install, Talisman may fail to add the pre-commit hook to this repository because one already exists for Husky. This is fine because it can still execute in the existing husky pre-commit hook, once installed.
 
 - During install, Talisman will also ask you for the directory of your git repositories. If you don't want to install Talisman in all your git repos, then cancel out at this step.
+
+
+## Run Cloud Carbon Footprint in an ephemeral workspace
+
+If you want to spin up an temporary development environment for Cloud Carbon Footprint, you can use Gitpod, an open source service for creating disposable environments to work on software projects.
+
+### Using the hosted service
+
+If you have an account on https://gitpod.io, you can open a workspace for the cloud carbon footprint project by following the link in your browser of the form `https://gitpod.io/#project-url-on-github`
+
+So for Cloud carbon footpring, you would visit:
+
+https://gitpod.io/#https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/
+
+This will run through the steps outlined in the documentation below install the necessary dependencies for the project, and open an instance of VS Code in your browser that you an work on immediately.
+
+If you want to check out a specific branch, or open a workspace for specific pull request or issue, add the full url for the issue or pull request you are interested in. A workspace will be created with the corresponding branch already checked out, that you can share with others to pair in, and use git to commit changes, before pushing your changes to the relevant the branch. 
+
+https://gitpod.io/#https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/pull/513
+https://gitpod.io/#https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/tree/recs-filter
+
+Shortly after you close the browser tab for your workspace, Gitpod will tear down and delete the workspace. For more information, please consult the [Gitpod docs](https://www.gitpod.io/docs/)
+
+### Using a self-hosted instance of gitpod
+
+If you need to, you can run also run gitpod on your own infrastructure, and use it to connect to source code repositories other than Github. [Doing so is well documented](https://www.gitpod.io/docs/self-hosted/latest), but beyond the scope of the docs for this project.
+


### PR DESCRIPTION
Would you accept a `.gitpod` file to support easily spinning up a ephemeral workspace to make it easier for folks to work on Cloud Carbon Footprint in future?

I finally found the time to look into the project, and part of me doing so was to set up a gitpod file so I can:

- develop in a workspace that isn't on my local machine
- pair with others more easily
- easily see the demo with mocked data 

[Gitpod](https://www.gitpod.io/) is an open-source-dev-environment-in-a-browser service with hosted options as well as on-prem options.

It's like the open version of Github Codespaces, if that helps.


## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->
I've added a sample. `.gitpod` file that:

- runs the installation steps for you as outlined in the docs
- runs the tests to check that the code is working as intended
- spins up an instance using mocked data to see what cloud carbon footprint is supposed to look like, in a way that lets you work on a browser based dev environment

I've spun it up with the start with mocked data thing largely to demonstrate it. I imagine you might want a different developer experience, and I'm happy to make the changes for that.

https://gitpod.io#https://github.com/thegreenwebfoundation/cloud-carbon-footprint/tree/ca-add-gitpod-for-dev-setup

BTW - the link above is a manual trigger of the [prebuild process](https://www.gitpod.io/docs/prebuilds) with gitpod. If you have this enabled on a repo, an environment is pre-built each time code is pushed to a repository, so rather than waiting a few minutes for the tests to run and installs to take place, you'd open up an environment where a terminal is open where a call to `yarn start-with-mock-data` has just been run.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added

## Notes

This is a WIP PR, and I expect I'd actually write docs about using something like Gitpod with all the prerequisite warnings, but I figured it was worth asking about the PR before going further.

I'd also expect to rebase the changes to tidy up the history before asking for a final review.

Please let me know if you want me to create a matching issue for this, or if you're happy discussing it here.
