### PR TITLE
[471] Remove width limitation on the app component

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -24,7 +24,7 @@ function App(): ReactElement {
     <>
       <HeaderBar />
 
-      <Container maxWidth={'xl'} className={classes.appContainer}>
+      <Container maxWidth={false} className={classes.appContainer}>
         <Switch>
           <Route path="/error" exact>
             <ErrorPage />


### PR DESCRIPTION
## Description of Change

Hello there.

This minor change should fix up the filter bar not stretching properly for wider resolutions.

The problem at the moment is that the `App` component sets a value of `'xl'` for the `maxWidth` prop, which will cap the width to `1920`. Setting this prop to a value of `false` disables the limitation.

![cap](https://user-images.githubusercontent.com/43751307/137235809-d2de579e-84b5-4b06-bac8-5ca53fd49200.gif)

Closes #471

## Checklist

- [x] PR description included and stakeholders cc'd
- [x] yarn test passes
- [x] yarn lint has been run

## Notes

None.