### PR TITLE
Show AWS account name instead of id

### DIFF
--- a/packages/aws/src/lib/CostAndUsageReportsRow.ts
+++ b/packages/aws/src/lib/CostAndUsageReportsRow.ts
@@ -4,7 +4,10 @@
 
 import { Athena } from 'aws-sdk'
 import { BillingDataRow } from '@cloud-carbon-footprint/core'
-import { containsAny } from '@cloud-carbon-footprint/common'
+import {
+  configLoader,
+  containsAny
+} from '@cloud-carbon-footprint/common'
 import {
   BURSTABLE_INSTANCE_BASELINE_UTILIZATION,
   EC2_INSTANCE_TYPES,
@@ -44,6 +47,15 @@ export default class CostAndUsageReportsRow extends BillingDataRow {
     this.cloudProvider = 'AWS'
     this.instanceType = this.parseInstanceTypeFromUsageType()
     this.replicationFactor = this.getReplicationFactor(billingDataRow)
+
+    const config = configLoader()
+    const AWS = config.AWS
+    for (const account of AWS.accounts) {
+      if (account.id === this.accountId) {
+        this.accountName = account.name
+        break
+      }
+    }
   }
 
   private getUsageAmount(): number {


### PR DESCRIPTION
## Description of Change

After configuring `AWS_ACCOUNTS` in `api/.env` (according to https://www.cloudcarbonfootprint.org/docs/configurations-glossary#variables-needed-for-the-cloud-usage-api-higher-accuracy-approach-with-aws) the account names are stored from there in the estimation cache.

Fixes #459.

## Checklist

- [x] PR description included and stakeholders cc'd
- [ ] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [ ] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] relevant documentation is changed or added
