### PR TITLE
Stop rounding to 0 in rec table and enable search for co2 in kgs

### DIFF
--- a/.changeset/tiny-countries-raise.md
+++ b/.changeset/tiny-countries-raise.md
@@ -1,0 +1,5 @@
+---
+'@cloud-carbon-footprint/client': patch
+---
+
+Stop rounding to 0 in rec table and enable search for co2 savings in kg

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
@@ -146,7 +146,7 @@ describe('Recommendations Table', () => {
   ]
 
   each(co2eSavingsToBeRounded).it(
-    'rounds the co2e savings to the nearest 0.001',
+    'rounds savings to nearest 0.001 - val %s',
     (savings, roundedSavings) => {
       const { getAllByRole } = render(
         <RecommendationsTable
@@ -193,7 +193,7 @@ describe('Recommendations Table', () => {
   ]
 
   each(co2eSavingsToBeRoundedInKilograms).it(
-    'rounds the co2e savings to the nearest 0.001',
+    'rounds savings in kg to nearest 0.001 - val %s',
     (savings, roundedSavingsInKilograms) => {
       const { getAllByRole } = render(
         <RecommendationsTable

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
@@ -135,6 +135,102 @@ describe('Recommendations Table', () => {
     actualRowData[0].forEach((cell) => expect(cell.innerHTML).toBe('-'))
   })
 
+  const co2eSavingsToBeRounded = [
+    [0.01, 0.01],
+    [0.001, 0.001],
+    [0.0005, 0.001],
+    [0.0001, 0],
+    [0.00001, 0],
+    [0.000001, 0],
+    [0.0000001, 0],
+  ]
+
+  each(co2eSavingsToBeRounded).it(
+    'rounds the co2e savings to the nearest 0.001',
+    (savings, roundedSavings) => {
+      const { getAllByRole } = render(
+        <RecommendationsTable
+          {...testProps}
+          recommendations={[
+            {
+              cloudProvider: undefined,
+              accountId: undefined,
+              accountName: undefined,
+              region: undefined,
+              recommendationType: undefined,
+              recommendationDetail: undefined,
+              costSavings: null,
+              co2eSavings: savings,
+              kilowattHourSavings: null,
+            },
+          ]}
+          useKilograms={false}
+        />,
+      )
+
+      const dataRows = getAllByRole('row')
+      dataRows.shift() // Removes row with table headers
+
+      const actualRowData = dataRows.map((row) =>
+        within(row).getAllByRole('cell'),
+      )
+
+      const firstRow = actualRowData[0]
+
+      // get last cell for CO2 data
+      expect(firstRow[firstRow.length - 1].innerHTML).toBe(`${roundedSavings}`)
+    },
+  )
+
+  const co2eSavingsToBeRoundedInKilograms = [
+    [0.01, 10],
+    [0.001, 1],
+    [0.0005, 0.5],
+    [0.0001, 0.1],
+    [0.00001, 0.01],
+    [0.000001, 0.001],
+    [0.0000001, 0],
+  ]
+
+  each(co2eSavingsToBeRoundedInKilograms).it(
+    'rounds the co2e savings to the nearest 0.001',
+    (savings, roundedSavingsInKilograms) => {
+      const { getAllByRole } = render(
+        <RecommendationsTable
+          {...testProps}
+          recommendations={[
+            {
+              cloudProvider: undefined,
+              accountId: undefined,
+              accountName: undefined,
+              region: undefined,
+              recommendationType: undefined,
+              recommendationDetail: undefined,
+              costSavings: null,
+              co2eSavings: savings,
+              kilowattHourSavings: null,
+            },
+          ]}
+          useKilograms={true}
+        />,
+      )
+
+      const dataRows = getAllByRole('row')
+      dataRows.shift() // Removes row with table headers
+
+      const actualRowData = dataRows.map((row) =>
+        within(row).getAllByRole('cell'),
+      )
+
+      const firstRow = actualRowData[0]
+
+      // get last cell for CO2 data
+      expect(firstRow[firstRow.length - 1].innerHTML).toBe(
+        `${roundedSavingsInKilograms}`,
+      )
+    },
+  )
+
   it('toggles CO2 units between metric tons and kilograms', () => {
     const mockRecommendations = [
       {

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
@@ -136,13 +136,13 @@ describe('Recommendations Table', () => {
   })
 
   const co2eSavingsToBeRounded = [
-    [0.01, 0.01],
-    [0.001, 0.001],
-    [0.0005, 0.001],
-    [0.0001, 0],
-    [0.00001, 0],
-    [0.000001, 0],
-    [0.0000001, 0],
+    [0.01, '0.01'],
+    [0.001, '0.001'],
+    [0.0005, '0.001'],
+    [0.0001, '< 0.001'],
+    [0.00001, '< 0.001'],
+    [0.000001, '< 0.001'],
+    [0.0000001, '< 0.001'],
   ]
 
   each(co2eSavingsToBeRounded).it(
@@ -178,18 +178,18 @@ describe('Recommendations Table', () => {
       const firstRow = actualRowData[0]
 
       // get last cell for CO2 data
-      expect(firstRow[firstRow.length - 1].innerHTML).toBe(`${roundedSavings}`)
+      expect(firstRow[firstRow.length - 1].textContent).toBe(roundedSavings)
     },
   )
 
   const co2eSavingsToBeRoundedInKilograms = [
-    [0.01, 10],
-    [0.001, 1],
-    [0.0005, 0.5],
-    [0.0001, 0.1],
-    [0.00001, 0.01],
-    [0.000001, 0.001],
-    [0.0000001, 0],
+    [0.01, '10'],
+    [0.001, '1'],
+    [0.0005, '0.5'],
+    [0.0001, '0.1'],
+    [0.00001, '0.01'],
+    [0.000001, '0.001'],
+    [0.0000001, '< 0.001'],
   ]
 
   each(co2eSavingsToBeRoundedInKilograms).it(
@@ -225,8 +225,8 @@ describe('Recommendations Table', () => {
       const firstRow = actualRowData[0]
 
       // get last cell for CO2 data
-      expect(firstRow[firstRow.length - 1].innerHTML).toBe(
-        `${roundedSavingsInKilograms}`,
+      expect(firstRow[firstRow.length - 1].textContent).toBe(
+        roundedSavingsInKilograms,
       )
     },
   )

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
@@ -287,22 +287,24 @@ describe('Recommendations Table', () => {
     })
 
     const searchedRecommendationsRows = [
-      ['test-b', true, 1],
-      ['AWS', true, 2],
-      ['us-west-1', true, 1],
-      ['Modify', true, 1],
-      [2.539, true, 1],
-      ['pizza', undefined, 0],
-      [6.2, undefined, 0],
+      ['test-b', true, 1, false],
+      ['AWS', true, 2, false],
+      ['us-west-1', true, 1, false],
+      ['Modify', true, 1, false],
+      [2.539, true, 1, false],
+      [2539, true, 1, true],
+      ['pizza', undefined, 0, false],
+      [6.2, undefined, 0, false],
     ]
 
     each(searchedRecommendationsRows).it(
       'should filter according to search bar value %s',
-      (searchValue, expectedResult, rowsLength) => {
+      (searchValue, expectedResult, rowsLength, useKilograms) => {
         const { getByRole, getAllByRole, getByLabelText } = render(
           <RecommendationsTable
             {...testProps}
             recommendations={mockRecommendationData}
+            useKilograms={useKilograms}
           />,
         )
 

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.tsx
@@ -165,7 +165,9 @@ const RecommendationsTable: FunctionComponent<RecommendationsTableProps> = ({
           if (!fieldsToNotFilter.includes(field)) {
             let value = row[field]
             if (field.includes('Savings')) {
-              value = Math.round(value * 1000) / 1000
+              value = useKilograms
+                ? Math.round(value * 1000)
+                : Math.round(value * 1000) / 1000
             }
             return searchRegex.test(value?.toString())
           }

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.tsx
@@ -124,9 +124,14 @@ const RecommendationsTable: FunctionComponent<RecommendationsTableProps> = ({
           // Replace any undefined values and round numbers to thousandth decimal
           Object.keys(recommendation).forEach((key) => {
             recommendationRow[key] = recommendationRow[key] ?? '-'
-            if (key.includes('Savings') && recommendationRow[key] != '-')
-              recommendationRow[key] =
+            if (key.includes('Savings') && recommendationRow[key] != '-') {
+              const roundedRecommendation =
                 Math.round(recommendationRow[key] * 1000) / 1000
+              recommendationRow[key] =
+                roundedRecommendation >= 0.001
+                  ? roundedRecommendation
+                  : '< 0.001'
+            }
           })
           return recommendationRow
         },


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

 @ericksod fixes #495 - stop rounding to 0 in rec table and enable search for co2 savings when units are kilograms

Please read the comments on linked issue to see a full summary of the changes.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
