### PR TITLE
[496] Allow side panel to be opened and closed by clicking the same rec row

### DIFF
--- a/.changeset/green-eagles-collect.md
+++ b/.changeset/green-eagles-collect.md
@@ -1,0 +1,5 @@
+---
+'@cloud-carbon-footprint/client': minor
+---
+
+Allow recommendations side panel to be opened and closed by clicking the same recommendation row. Also fixed bug where side panel would not reopen for same recommendation row after being closed

--- a/packages/app/src/EstimatorCache.ts
+++ b/packages/app/src/EstimatorCache.ts
@@ -6,6 +6,6 @@ import { EstimationResult } from '@cloud-carbon-footprint/common'
 import { EstimationRequest } from './CreateValidRequest'
 
 export default interface EstimatorCache {
-  getEstimates(request: EstimationRequest): Promise<EstimationResult[]>
+  getEstimates(request: EstimationRequest): Promise<EstimationResult[] | void>
   setEstimates(data: EstimationResult[]): void
 }

--- a/packages/app/src/EstimatorCache.ts
+++ b/packages/app/src/EstimatorCache.ts
@@ -6,6 +6,6 @@ import { EstimationResult } from '@cloud-carbon-footprint/common'
 import { EstimationRequest } from './CreateValidRequest'
 
 export default interface EstimatorCache {
-  getEstimates(request: EstimationRequest): Promise<EstimationResult[] | void>
+  getEstimates(request: EstimationRequest): Promise<EstimationResult[]>
   setEstimates(data: EstimationResult[]): void
 }

--- a/packages/app/src/EstimatorCacheGoogleCloudStorage.ts
+++ b/packages/app/src/EstimatorCacheGoogleCloudStorage.ts
@@ -24,7 +24,7 @@ export default class EstimatorCacheGoogleCloudStorage
     this.cacheFileName = cacheFileName
   }
 
-  getEstimates(): Promise<EstimationResult[]> {
+  getEstimates(): Promise<EstimationResult[] | void> {
     return this.getCloudFileContent()
   }
 
@@ -48,14 +48,14 @@ export default class EstimatorCacheGoogleCloudStorage
     }
   }
 
-  private async getCloudFileContent(): Promise<EstimationResult[]> {
+  private async getCloudFileContent(): Promise<EstimationResult[] | void> {
     try {
-      const streamOfcacheFile = storage
+      const streamOfCacheFile = storage
         .bucket(this.bucketName)
         .file(this.cacheFileName)
 
       const cachedJson = await this.streamToString(
-        await streamOfcacheFile.createReadStream(),
+        await streamOfCacheFile.createReadStream(),
       )
 
       const dateTimeReviver = (key: string, value: string) => {

--- a/packages/app/src/EstimatorCacheGoogleCloudStorage.ts
+++ b/packages/app/src/EstimatorCacheGoogleCloudStorage.ts
@@ -24,7 +24,7 @@ export default class EstimatorCacheGoogleCloudStorage
     this.cacheFileName = cacheFileName
   }
 
-  getEstimates(): Promise<EstimationResult[] | void> {
+  getEstimates(): Promise<EstimationResult[]> {
     return this.getCloudFileContent()
   }
 
@@ -48,7 +48,7 @@ export default class EstimatorCacheGoogleCloudStorage
     }
   }
 
-  private async getCloudFileContent(): Promise<EstimationResult[] | void> {
+  private async getCloudFileContent(): Promise<EstimationResult[]> {
     try {
       const streamOfCacheFile = storage
         .bucket(this.bucketName)
@@ -70,6 +70,7 @@ export default class EstimatorCacheGoogleCloudStorage
       if (err.code !== 404) {
         console.warn(`Error loading cloud data: ${err.message}`)
       }
+      return []
     }
   }
 

--- a/packages/client/src/Types.ts
+++ b/packages/client/src/Types.ts
@@ -81,6 +81,7 @@ export type SidePanelProps = {
   children: ReactNode
   defaultIsOpen?: boolean
   openOnChange?: RecommendationRow
+  onClose?: () => void
 }
 
 export type FilterProps = {

--- a/packages/client/src/common/SidePanel/SidePanel.tsx
+++ b/packages/client/src/common/SidePanel/SidePanel.tsx
@@ -31,6 +31,9 @@ const SidePanel: FunctionComponent<SidePanelProps> = (props) => {
 
   const handleDrawerClose = () => {
     setOpen(false)
+    if (props.onClose) {
+      props.onClose()
+    }
   }
 
   const drawerStatus = open ? 'open' : 'closed'

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsPage.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsPage.test.tsx
@@ -13,6 +13,7 @@ import { generateEstimations, mockRecommendationData } from 'utils/data'
 import { useRemoteRecommendationsService, useRemoteService } from 'utils/hooks'
 import { ServiceResult } from 'Types'
 import moment from 'moment'
+import { act } from 'react-dom/test-utils'
 
 jest.mock('utils/hooks/RecommendationsServiceHook')
 jest.mock('utils/hooks/RemoteServiceHook')
@@ -103,6 +104,65 @@ describe('Recommendations Page', () => {
     const { getByText, queryByTestId } = render(<RecommendationsPage />)
 
     expect(queryByTestId('sideBarTitle')).toBeFalsy()
+
+    fireEvent.click(screen.getByText('test-a'))
+    const recommendationDetail = getByText(
+      mockRecommendationData[0].recommendationDetail,
+    )
+
+    expect(queryByTestId('sideBarTitle')).toBeInTheDocument()
+    expect(recommendationDetail).toBeInTheDocument()
+  })
+
+  it('hides and re-displays the side panel when a recommendation row is clicked multiple times', () => {
+    const { getByText, queryByTestId } = render(<RecommendationsPage />)
+
+    fireEvent.click(screen.getByText('test-a'))
+    fireEvent.click(screen.getByText('test-a', { selector: 'div' }))
+    // selector added because now there are multiple elements with the text 'test-a' on the screen
+
+    expect(queryByTestId('sideBarTitle')).toBeFalsy()
+
+    fireEvent.click(screen.getByText('test-a'))
+    const recommendationDetail = getByText(
+      mockRecommendationData[0].recommendationDetail,
+    )
+
+    expect(queryByTestId('sideBarTitle')).toBeInTheDocument()
+    expect(recommendationDetail).toBeInTheDocument()
+  })
+
+  it('displays a new recommendation in the side panel when its recommendation row is clicked', () => {
+    const { getByText, queryByText, queryByTestId } = render(
+      <RecommendationsPage />,
+    )
+
+    fireEvent.click(screen.getByText('test-a'))
+    fireEvent.click(screen.getByText('test-b'))
+    const firstRecommendationDetail = queryByText(
+      mockRecommendationData[0].recommendationDetail,
+    )
+    const secondRecommendationDetail = getByText(
+      mockRecommendationData[1].recommendationDetail,
+    )
+
+    expect(queryByTestId('sideBarTitle')).toBeInTheDocument()
+    expect(firstRecommendationDetail).toBeFalsy()
+    expect(secondRecommendationDetail).toBeInTheDocument()
+  })
+
+  it('re-displays the side panel when the close button and then the same recommendation row is clicked', () => {
+    const { getByText, getByTestId, queryByTestId } = render(
+      <RecommendationsPage />,
+    )
+
+    fireEvent.click(screen.getByText('test-a'))
+
+    const closeIcon = getByTestId('closeIcon')
+
+    act(() => {
+      fireEvent.click(closeIcon)
+    })
 
     fireEvent.click(screen.getByText('test-a'))
     const recommendationDetail = getByText(

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsPage.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsPage.tsx
@@ -73,7 +73,14 @@ const RecommendationsPage = (): ReactElement => {
     params: GridRowParams,
     _event: MuiEvent<SyntheticEvent>,
   ) => {
-    setSelectedRecommendation(params.row as RecommendationRow)
+    if (
+      selectedRecommendation &&
+      params.row.accountId === selectedRecommendation.accountId
+    ) {
+      setSelectedRecommendation(undefined)
+    } else {
+      setSelectedRecommendation(params.row as RecommendationRow)
+    }
   }
 
   if (recommendationsLoading || emissionsLoading)
@@ -92,7 +99,10 @@ const RecommendationsPage = (): ReactElement => {
       <div className={classes.boxContainer}>
         <Grid container spacing={3}>
           {selectedRecommendation && (
-            <RecommendationsSidePanel recommendation={selectedRecommendation} />
+            <RecommendationsSidePanel
+              recommendation={selectedRecommendation}
+              onClose={() => setSelectedRecommendation(undefined)}
+            />
           )}
           <RecommendationsTable
             emissionsData={filteredEmissionsData}

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsPage.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsPage.tsx
@@ -75,7 +75,7 @@ const RecommendationsPage = (): ReactElement => {
   ) => {
     if (
       selectedRecommendation &&
-      params.row.accountId === selectedRecommendation.accountId
+      params.row.id === selectedRecommendation.id
     ) {
       setSelectedRecommendation(undefined)
     } else {

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsSidePanel/RecommendationsSidePanel.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsSidePanel/RecommendationsSidePanel.tsx
@@ -11,10 +11,11 @@ import useStyles from './recommendationsSidePanelStyles'
 
 type RecommendationsSidePanelProps = {
   recommendation: RecommendationRow
+  onClose: () => void
 }
 
 const RecommendationsSidePanel: FunctionComponent<RecommendationsSidePanelProps> =
-  ({ recommendation }): ReactElement => {
+  ({ recommendation, onClose }): ReactElement => {
     const classes = useStyles()
 
     return (
@@ -23,6 +24,7 @@ const RecommendationsSidePanel: FunctionComponent<RecommendationsSidePanelProps>
         title="Recommendation Details"
         defaultIsOpen
         openOnChange={recommendation}
+        onClose={onClose}
       >
         <Container className={classes.detailsContainer}>
           <RecommendationsPanelRow

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "experimentalDecorators": true,
     "target": "ES5",
     "downlevelIteration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noImplicitReturns": true,
   },
   "include": ["./src"],
   "exclude": ["node_modules", "scripts", "**/__tests__/**" , "**/*.test.*",]


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

@ericksod fixes #496 - user can close and reopen the rec panel for the same rec row and additionally by clicking repeatedly on the row.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
