### PR TITLE
Add IAM auth mode

### DIFF
--- a/microsite/docs/AWS.md
+++ b/microsite/docs/AWS.md
@@ -8,7 +8,7 @@ Your AWS account needs to be configured to generate Cost and Usage reports and s
 1.  Ensure your aws account has the correct permissions
 
     - You will need an [IAM](https://aws.amazon.com/premiumsupport/knowledge-center/create-access-key/) user that can create access-keys and modify your billing settings.
-    - You can use the CloudFormation template file [ccf-athena.yaml](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/cloudformation/ccf-athena.yaml) to automate the creation of a role that allows the Cloud Carbon Footprint application to read Cost and Usage Reports via AWS Athena. Note: the section that asks you to specify the "AssumeRolePolicyDocument" is where you define the user or role that will have permissions to assume the "ccf-athena" role. 
+    - You can use the CloudFormation template file [ccf-athena.yaml](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/cloudformation/ccf-athena.yaml) to automate the creation of a role that allows the Cloud Carbon Footprint application to read Cost and Usage Reports via AWS Athena. Note: the section that asks you to specify the "AssumeRolePolicyDocument" is where you define the user or role that will have permissions to assume the "ccf-athena" role.
     - This role name will be used for the value in the environment variable: `AWS_TARGET_ACCOUNT_ROLE_NAME`
 
 2.  Enable the Cost and Usage Billing AWS feature.
@@ -65,6 +65,8 @@ We currently support three modes of authentication with AWS, that you can see in
 2. "AWS" - this is used to authenticate via an AWS role that has the necessary permissions to query the CloudWatch and Cost Explorer APIs.
 
 3. "GCP" - this is used by GCP Service Accounts that authenticate via a temporary AWS STS token. This method is used by the application when deployed to Google App Engine.
+
+4. "EC2-METADATA" - this uses the AWS credentials that are automatically provided via an Instance Profile when you run the application on an EC2 instance. In order for this to work, you need to make sure that the appropriate IAM role is already created (as specified in step 1 of this document), and associated with the EC2 instance. See more information [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html).
 
 The authentication mode is set inside [packages/common/src/Config.ts.](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/packages/common/src/Config.ts)
 

--- a/packages/aws/src/__tests__/AWSCredentialsProvider.test.ts
+++ b/packages/aws/src/__tests__/AWSCredentialsProvider.test.ts
@@ -106,7 +106,7 @@ describe('AWSCredentialsProvider', () => {
 
   it('create returns EC2MetadataCredentials', () => {
     // given
-    mockConfig.AWS.authentication.mode = 'IAM'
+    mockConfig.AWS.authentication.mode = 'EC2-METADATA'
     const options = { httpOptions: { timeout: 5000 }, maxRetries: 10 }
     const mockedEC2MetadataCredentials = mockEC2MetadataCredentials(options)
     const accountId = '123'

--- a/packages/aws/src/application/AWSCredentialsProvider.ts
+++ b/packages/aws/src/application/AWSCredentialsProvider.ts
@@ -6,6 +6,7 @@ import {
   Credentials,
   config as awsConfig,
   ChainableTemporaryCredentials,
+  EC2MetadataCredentials,
 } from 'aws-sdk'
 import { configLoader } from '@cloud-carbon-footprint/common'
 import GCPCredentials from './GCPCredentials'
@@ -29,6 +30,11 @@ export default class AWSCredentialsProvider {
             RoleSessionName:
               configLoader().AWS.authentication.options.targetRoleName,
           },
+        })
+      case 'IAM':
+        return new EC2MetadataCredentials({
+          httpOptions: { timeout: 5000 },
+          maxRetries: 10,
         })
       default:
         return new Credentials(awsConfig.credentials)

--- a/packages/aws/src/application/AWSCredentialsProvider.ts
+++ b/packages/aws/src/application/AWSCredentialsProvider.ts
@@ -31,7 +31,7 @@ export default class AWSCredentialsProvider {
               configLoader().AWS.authentication.options.targetRoleName,
           },
         })
-      case 'IAM':
+      case 'EC2-METADATA':
         return new EC2MetadataCredentials({
           httpOptions: { timeout: 5000 },
           maxRetries: 10,


### PR DESCRIPTION
## Description of Change

This PR adds a new auth mode for the application. The IAM mode relies on using the permissions available to the application via an EC2 instance profile. 

It requires the application to be running on an EC2 instance that has been provisioned with the application and all env vars are setup correctly. Moreover, the EC2 instance needs to have attached a role that should have all the permissions required by the app (same role/policies as defined via CloudFormation)

## Checklist

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)

## Notes

N/A

© 2021 Thoughtworks, Inc.
