### PR TITLE
Updated API router to accept a CCF Config

### DIFF
--- a/packages/api/src/api.test.ts
+++ b/packages/api/src/api.test.ts
@@ -37,7 +37,7 @@ describe('api', () => {
 
   beforeEach(() => {
     server = express()
-    server.use(api)
+    server.use(api())
   })
 
   describe('/footprint', () => {

--- a/packages/api/src/api.test.ts
+++ b/packages/api/src/api.test.ts
@@ -11,7 +11,7 @@ import {
   RecommendationResult,
 } from '@cloud-carbon-footprint/common'
 
-import api from './api'
+import { createRouter } from './api'
 
 const mockGetCostAndEstimates = jest.fn()
 const mockGetEmissionsFactors = jest.fn()
@@ -37,7 +37,7 @@ describe('api', () => {
 
   beforeEach(() => {
     server = express()
-    server.use(api())
+    server.use(createRouter())
   })
 
   describe('/footprint', () => {

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -114,7 +114,7 @@ const RecommendationsApiMiddleware = async function (
   }
 }
 
-const createRouter = (config?: CCFConfig) => {
+export const createRouter = (config?: CCFConfig) => {
   setConfig(config)
 
   const router = express.Router()
@@ -128,5 +128,3 @@ const createRouter = (config?: CCFConfig) => {
 
   return router
 }
-
-export default createRouter

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -13,6 +13,8 @@ import {
 } from '@cloud-carbon-footprint/app'
 
 import {
+  setConfig,
+  CCFConfig,
   EstimationRequestValidationError,
   Logger,
   PartialDataError,
@@ -112,12 +114,19 @@ const RecommendationsApiMiddleware = async function (
   }
 }
 
-const router = express.Router()
+const createRouter = (config?: CCFConfig) => {
+  setConfig(config)
 
-router.get('/footprint', FootprintApiMiddleware)
-router.get('/regions/emissions-factors', EmissionsApiMiddleware)
-router.get('/recommendations', RecommendationsApiMiddleware)
-router.get('/healthz', (req: express.Request, res: express.Response) => {
-  res.status(200).send('OK')
-})
-export default router
+  const router = express.Router()
+
+  router.get('/footprint', FootprintApiMiddleware)
+  router.get('/regions/emissions-factors', EmissionsApiMiddleware)
+  router.get('/recommendations', RecommendationsApiMiddleware)
+  router.get('/healthz', (req: express.Request, res: express.Response) => {
+    res.status(200).send('OK')
+  })
+
+  return router
+}
+
+export default createRouter

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -9,7 +9,7 @@ if (process.env.NODE_ENV === 'production') {
 import express from 'express'
 import helmet from 'helmet'
 
-import api from './api'
+import { createRouter } from './api'
 import auth from './auth'
 import { Logger } from '@cloud-carbon-footprint/common'
 
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV === 'production') {
 
 httpApp.use(helmet())
 
-httpApp.use('/api', api())
+httpApp.use('/api', createRouter())
 
 httpApp.listen(port, () =>
   serverLogger.info(

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV === 'production') {
 
 httpApp.use(helmet())
 
-httpApp.use('/api', api)
+httpApp.use('/api', api())
 
 httpApp.listen(port, () =>
   serverLogger.info(

--- a/packages/app/src/App.ts
+++ b/packages/app/src/App.ts
@@ -22,10 +22,7 @@ import {
   AWS_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
   AWSAccount,
 } from '@cloud-carbon-footprint/aws'
-import {
-  GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
-  GCPAccount,
-} from '@cloud-carbon-footprint/gcp'
+import { getGCPEmissionsFactors, GCPAccount } from '@cloud-carbon-footprint/gcp'
 import { OnPremise } from '@cloud-carbon-footprint/on-premise'
 
 import cache from './Cache'
@@ -129,7 +126,7 @@ export default class App {
   getEmissionsFactors(): EmissionRatioResult[] {
     const CLOUD_PROVIDER_EMISSIONS_FACTORS_METRIC_TON_PER_KWH = {
       AWS: AWS_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
-      GCP: GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
+      GCP: getGCPEmissionsFactors(),
       AZURE: AZURE_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
     }
 

--- a/packages/app/src/CacheManager.ts
+++ b/packages/app/src/CacheManager.ts
@@ -12,14 +12,13 @@ import EstimatorCacheGoogleCloudStorage from './EstimatorCacheGoogleCloudStorage
 
 const cacheService: EstimatorCache = new EstimatorCacheFileSystem()
 const googleCloudCacheService: EstimatorCache =
-  new EstimatorCacheGoogleCloudStorage(configLoader().GCP.CACHE_BUCKET_NAME)
+  new EstimatorCacheGoogleCloudStorage()
 
 export default class CacheManager implements EstimatorCache {
   private readonly currentCacheMode: string
   private readonly cacheLogger: Logger
 
   constructor() {
-    this.currentCacheMode = configLoader().CACHE_MODE
     this.cacheLogger = new Logger('cache')
   }
 
@@ -34,7 +33,7 @@ export default class CacheManager implements EstimatorCache {
     const { GCS } = this.cacheModes
     let estimates
 
-    switch (this.currentCacheMode) {
+    switch (configLoader().CACHE_MODE) {
       case GCS:
         this.cacheLogger.info('Using GCS bucket cache file...')
         estimates = await googleCloudCacheService.getEstimates(
@@ -61,7 +60,7 @@ export default class CacheManager implements EstimatorCache {
       return
     }
 
-    switch (this.currentCacheMode) {
+    switch (configLoader().CACHE_MODE) {
       case GCS:
         return googleCloudCacheService.setEstimates(estimates, grouping)
       default:

--- a/packages/app/src/__tests__/App.test.ts
+++ b/packages/app/src/__tests__/App.test.ts
@@ -90,10 +90,10 @@ jest.mock('@cloud-carbon-footprint/gcp', () => ({
     string,
     unknown
   >),
-  GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH: {
+  getGCPEmissionsFactors: jest.fn().mockReturnValue({
     gcpRegion1: 3,
     gcpRegion2: 4,
-  },
+  }),
 }))
 
 jest.mock('@cloud-carbon-footprint/azure', () => ({

--- a/packages/common/src/Config.ts
+++ b/packages/common/src/Config.ts
@@ -103,7 +103,7 @@ const getEnvVar = (envVar: string): string => {
   }
 }
 
-export const appConfig: CCFConfig = {
+const getConfig = (): CCFConfig => ({
   AWS: {
     USE_BILLING_DATA:
       !!process.env.AWS_USE_BILLING_DATA &&
@@ -237,6 +237,6 @@ export const appConfig: CCFConfig = {
       AVERAGE_WATTS: parseFloat(getEnvVar('ON_PREMISE_AVG_WATTS_DESKTOP')),
     },
   },
-}
+})
 
-export default appConfig
+export default getConfig

--- a/packages/common/src/ConfigLoader.ts
+++ b/packages/common/src/ConfigLoader.ts
@@ -2,8 +2,14 @@
  * © 2021 Thoughtworks, Inc.
  */
 
-import configFile, { CCFConfig } from './Config'
+import getConfig, { CCFConfig } from './Config'
+
+let _config: CCFConfig = undefined
+
+export const setConfig = (ccfConfig: CCFConfig = getConfig()) => {
+  return (_config = ccfConfig)
+}
 
 export default function config(): CCFConfig {
-  return configFile
+  return _config
 }

--- a/packages/common/src/__tests__/Config.test.ts
+++ b/packages/common/src/__tests__/Config.test.ts
@@ -1,0 +1,44 @@
+/*
+ * © 2022 Thoughtworks, Inc.
+ */
+
+import fs from 'fs'
+import getConfig from '../Config'
+
+describe('Config', () => {
+  it('get AWS accounts', () => {
+    const id = 'b47m4n'
+    const name = 'Bruce Wayne'
+    process.env.AWS_ACCOUNTS = `[{"id": "${id}", "name": "${name}"}]`
+    const config = getConfig()
+    expect(config.AWS.accounts[0].id).toBe(id)
+    expect(config.AWS.accounts[0].name).toBe(name)
+    // Avoid side effects
+    delete process.env.AWS_ACCOUNTS
+  })
+
+  it('get GCP projects', () => {
+    const id = 'id'
+    const name = 'project'
+    process.env.GCP_PROJECTS = `[{"id": "${id}", "name": "${name}"}]`
+    const config = getConfig()
+    expect(config.GCP.projects[0].id).toBe(id)
+    expect(config.GCP.projects[0].name).toBe(name)
+    // Avoid side effects
+    delete process.env.GCP_PROJECTS
+  })
+
+  it('get environment variable from `process.env`', () => {
+    const fsSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw new Error()
+    })
+    const billingId = 'ezb1'
+    process.env.AWS_BILLING_ACCOUNT_ID = billingId
+    const config = getConfig()
+    expect(fsSpy).toBeCalled()
+    expect(config.AWS.BILLING_ACCOUNT_ID).toBe(billingId)
+    // Avoid side effects
+    delete process.env.AWS_BILLING_ACCOUNT_ID
+    jest.clearAllMocks()
+  })
+})

--- a/packages/common/src/__tests__/Logger.test.ts
+++ b/packages/common/src/__tests__/Logger.test.ts
@@ -27,17 +27,20 @@ jest.mock('winston', () => {
 })
 
 import Logger from '../Logger'
-import mockConfig from '../Config'
+import { setConfig } from '../ConfigLoader'
 
 describe('Logger', () => {
   const testMessage = 'test log message'
   const testErr = new Error('error test message')
 
   describe('Default logger', () => {
-    const testLogger = new Logger('test')
+    let testLogger: Logger = undefined
 
-    afterEach(() => {
-      jest.resetAllMocks()
+    beforeEach(() => {
+      setConfig({
+        LOGGING_MODE: null,
+      })
+      testLogger = new Logger('test')
     })
 
     it('logs debug', () => {
@@ -76,11 +79,14 @@ describe('Logger', () => {
   })
 
   describe('GCP logger', () => {
-    mockConfig.LOGGING_MODE = 'GCP'
-    const testLogger = new Logger('test')
+    let testLogger: Logger = undefined
 
-    afterEach(() => {
-      jest.resetAllMocks()
+    beforeEach(() => {
+      setConfig({
+        LOGGING_MODE: 'GCP',
+      })
+
+      testLogger = new Logger('test')
     })
 
     it('logs debug', () => {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 export { default as Logger } from './Logger'
-export { default as configLoader } from './ConfigLoader'
+export { default as configLoader, setConfig } from './ConfigLoader'
 export { default as Config } from './Config'
 export type { QUERY_DATE_TYPES, CCFConfig } from './Config'
 export { GroupBy } from './Config'

--- a/packages/gcp/src/application/GCPAccount.ts
+++ b/packages/gcp/src/application/GCPAccount.ts
@@ -32,10 +32,7 @@ import {
 } from '@cloud-carbon-footprint/common'
 import ServiceWrapper from '../lib/ServiceWrapper'
 import { BillingExportTable, ComputeEngine, Recommendations } from '../lib'
-import {
-  GCP_CLOUD_CONSTANTS,
-  GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
-} from '../domain'
+import { GCP_CLOUD_CONSTANTS, getGCPEmissionsFactors } from '../domain'
 
 export default class GCPAccount extends CloudProviderAccount {
   constructor(
@@ -79,7 +76,7 @@ export default class GCPAccount extends CloudProviderAccount {
     const region = new Region(
       regionId,
       gcpServices,
-      GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
+      getGCPEmissionsFactors(),
       gcpConstants,
     )
     return await this.getRegionData('GCP', region, startDate, endDate, grouping)

--- a/packages/gcp/src/domain/GcpFootprintEstimationConstants.ts
+++ b/packages/gcp/src/domain/GcpFootprintEstimationConstants.ts
@@ -140,7 +140,7 @@ export const GCP_CLOUD_CONSTANTS: CloudConstantsByProvider = {
   SERVER_EXPECTED_LIFESPAN: 35040, // 4 years in hours
 }
 
-const getGCPEmissionsFactors = (): CloudConstantsEmissionsFactors => {
+export const getGCPEmissionsFactors = (): CloudConstantsEmissionsFactors => {
   // These emission factors take into account Google Carbon Free Energy percentage in each region. Source: https://cloud.google.com/sustainability/region-carbon
   if (configLoader().GCP.USE_CARBON_FREE_ENERGY_PERCENTAGE)
     return {
@@ -219,6 +219,3 @@ const getGCPEmissionsFactors = (): CloudConstantsEmissionsFactors => {
     [GCP_REGIONS.UNKNOWN]: 0.0004116296296, // Average of the above regions
   }
 }
-
-export const GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH: CloudConstantsEmissionsFactors =
-  getGCPEmissionsFactors()

--- a/packages/gcp/src/domain/index.ts
+++ b/packages/gcp/src/domain/index.ts
@@ -1,4 +1,4 @@
 export {
-  GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
+  getGCPEmissionsFactors,
   GCP_CLOUD_CONSTANTS,
 } from './GcpFootprintEstimationConstants'

--- a/packages/gcp/src/lib/BillingExportTable.ts
+++ b/packages/gcp/src/lib/BillingExportTable.ts
@@ -60,10 +60,7 @@ import {
   SHARED_CORE_PROCESSORS,
 } from './MachineTypes'
 import BillingExportRow from './BillingExportRow'
-import {
-  GCP_CLOUD_CONSTANTS,
-  GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
-} from '../domain'
+import { GCP_CLOUD_CONSTANTS, getGCPEmissionsFactors } from '../domain'
 import { GCP_REPLICATION_FACTORS_FOR_SERVICES } from './ReplicationFactors'
 
 export default class BillingExportTable {
@@ -197,7 +194,7 @@ export default class BillingExportTable {
     unknownRows: BillingExportRow[],
   ): FootprintEstimate | void {
     const emissionsFactors: CloudConstantsEmissionsFactors =
-      GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH
+      getGCPEmissionsFactors()
     const powerUsageEffectiveness: number = GCP_CLOUD_CONSTANTS.getPUE(
       billingExportRow.region,
     )
@@ -584,7 +581,7 @@ export default class BillingExportTable {
     return this.unknownEstimator.estimate(
       [unknownUsage],
       rowData.region,
-      GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
+      getGCPEmissionsFactors(),
       unknownConstants,
     )[0]
   }

--- a/packages/gcp/src/lib/Recommendations.ts
+++ b/packages/gcp/src/lib/Recommendations.ts
@@ -23,10 +23,7 @@ import {
   Logger,
   RecommendationResult,
 } from '@cloud-carbon-footprint/common'
-import {
-  GCP_CLOUD_CONSTANTS,
-  GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
-} from '../domain'
+import { GCP_CLOUD_CONSTANTS, getGCPEmissionsFactors } from '../domain'
 import {
   INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING,
   SHARED_CORE_PROCESSORS_BASELINE_UTILIZATION,
@@ -190,8 +187,7 @@ export default class Recommendations implements ICloudRecommendationsService {
       this.costAndCo2eTotals.kilowattHours / this.costAndCo2eTotals.cost
     const kilowattHours = cost * kilowattHoursPerCost
     const co2e =
-      kilowattHours *
-      GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH[this.parseRegionFromZone(zone)]
+      kilowattHours * getGCPEmissionsFactors()[this.parseRegionFromZone(zone)]
     return { co2e, kilowattHours }
   }
 
@@ -464,7 +460,7 @@ export default class Recommendations implements ICloudRecommendationsService {
     return this.computeEstimator.estimate(
       [computeUsage],
       region,
-      GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
+      getGCPEmissionsFactors(),
       computeConstants,
     )[0]
   }
@@ -491,7 +487,7 @@ export default class Recommendations implements ICloudRecommendationsService {
       ...storageEstimator.estimate(
         [storageUsage],
         region,
-        GCP_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
+        getGCPEmissionsFactors(),
         storageConstants,
       )[0],
     }


### PR DESCRIPTION
## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] tests are changed or added
- [ ] yarn test passes
- [ ] yarn lint has been run
- [ ] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [ ] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] relevant documentation is changed or added

## Notes

Hi 👋  As part of Spotify's Climate Change Hackweek we're looking at putting the CCF dashboard into a [Backstage plugin ](https://github.com/backstage/backstage). 

The approach we're trying out is plugging the CCF express router into Backstages express server, like so... 

```ts
import ccfRouter from '@cloud-carbon-footprint/api/dist/api';

app.use(ccfRouter({
  AZURE: {
     USE_BILLING_DATA: bsConfigLoader.get('...'),,
     authentication: {
        mode: bsConfigLoader.get('...'),
        clientId: bsConfigLoader.get('...'),
        clientSecret: bsConfigLoader.get('...'),
        tenantId: bsConfigLoader.get('...'),
      }   
  }
}));
```

Backstage has it's own configLoader system, this PR makes changes to allow a CCFConfig to be passed in and set inside the router. Please let us know your thoughts, if this is a welcomed change and/or if there's a better way to go about this. 

Additional information relevant to the changes

_The `'@cloud-carbon-footprint/api/dist/api` isn't ideal, and if this is a welcomed change, then we can look into having the router as a top level export?_

© 2021 Thoughtworks, Inc.
