### PR TITLE
Filter footprint on subscriptionIds (for Azure). Fixes #828

### DIFF
--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -41,6 +41,7 @@ const FootprintApiMiddleware = async function (
     endDate: req.query.end?.toString(),
     ignoreCache: req.query.ignoreCache?.toString(),
     groupBy: req.query.groupBy?.toString(),
+    subscriptionIds: req.query.subscriptionIds?.toString()
   }
   apiLogger.info(
     `Footprint API request started with Start Date: ${rawRequest.startDate} and End Date: ${rawRequest.endDate}`,

--- a/packages/app/src/App.ts
+++ b/packages/app/src/App.ts
@@ -42,6 +42,7 @@ export default class App {
     const endDate = request.endDate
     const grouping =
       (request.groupBy as GroupBy) || configLoader().GROUP_QUERY_RESULTS_BY
+    const subscriptionIds = request.subscriptionIds;
     const config = configLoader()
     const AWS = config.AWS
     const GCP = config.GCP
@@ -117,6 +118,7 @@ export default class App {
           startDate,
           endDate,
           grouping,
+          subscriptionIds
         )
         appLogger.info('Finished Azure Estimations')
         AzureEstimatesByRegion.push(estimates)

--- a/packages/app/src/Cache.ts
+++ b/packages/app/src/Cache.ts
@@ -83,7 +83,7 @@ export default function cache(): any {
         )
         cacheLogger.info('Setting new estimates to cache file...')
         if (estimatesToPersist.length > 0) {
-          await cacheManager.setEstimates(estimatesToPersist, grouping)
+          await cacheManager.setEstimates(estimatesToPersist, grouping, request.subscriptionIds)
         }
       }
 

--- a/packages/app/src/Cache.ts
+++ b/packages/app/src/Cache.ts
@@ -171,6 +171,7 @@ function getMissingDataRequests(
       ignoreCache: false,
       groupBy: request.groupBy,
       region: request.region,
+      subscriptionIds: request.subscriptionIds
     }
   })
 }

--- a/packages/app/src/CacheManager.ts
+++ b/packages/app/src/CacheManager.ts
@@ -30,7 +30,7 @@ export default abstract class CacheManager {
    * @param data     Data to be cached
    * @param grouping String representing how the data is being grouped
    */
-  abstract setEstimates(data: EstimationResult[], grouping: string): void
+  abstract setEstimates(data: EstimationResult[], grouping: string, subscriptionIds?: string): void
 
   protected filterEstimatesForRequest(
     request: EstimationRequest,

--- a/packages/app/src/CreateValidRequest.ts
+++ b/packages/app/src/CreateValidRequest.ts
@@ -23,6 +23,7 @@ export interface EstimationRequest {
   region?: string
   ignoreCache: boolean
   groupBy?: string
+  subscriptionIds?: string
   //cloudProvider?:CloudProviderEnum
 }
 
@@ -122,6 +123,7 @@ function rawRequestToEstimationRequest(
     region: request.region,
     ignoreCache,
     groupBy,
+    subscriptionIds: request.subscriptionIds
   }
 }
 

--- a/packages/app/src/GoogleCloudCacheManager.ts
+++ b/packages/app/src/GoogleCloudCacheManager.ts
@@ -20,20 +20,21 @@ export default class GoogleCloudCacheManager extends CacheManager {
     grouping: string,
   ): Promise<EstimationResult[]> {
     this.cacheLogger.info('Using GCS bucket cache file...')
-    const estimates = await this.getCloudFileContent(grouping)
+    const estimates = await this.getCloudFileContent(grouping, request.subscriptionIds)
     return estimates ? this.filterEstimatesForRequest(request, estimates) : []
   }
 
   async setEstimates(
     estimates: EstimationResult[],
     grouping: string,
+    subscriptionIds?: string
   ): Promise<void> {
-    const cachedEstimates = await this.getCloudFileContent(grouping)
+    const cachedEstimates = await this.getCloudFileContent(grouping, subscriptionIds)
     const bucketName = configLoader().GCP.CACHE_BUCKET_NAME
     const mergedData = cachedEstimates
       ? cachedEstimates.concat(estimates)
       : estimates
-    const cacheFileName = getCacheFileName(grouping)
+    const cacheFileName = getCacheFileName(grouping, subscriptionIds)
 
     try {
       const cacheFile = storage.bucket(bucketName).file(cacheFileName)
@@ -50,8 +51,9 @@ export default class GoogleCloudCacheManager extends CacheManager {
 
   private async getCloudFileContent(
     grouping: string,
+    subscriptionIds?: string
   ): Promise<EstimationResult[]> {
-    const cacheFileName = getCacheFileName(grouping)
+    const cacheFileName = getCacheFileName(grouping, subscriptionIds)
     const bucketName = configLoader().GCP.CACHE_BUCKET_NAME
     let cachedData: EstimationResult[] | any = []
     try {

--- a/packages/app/src/LocalCacheManager.ts
+++ b/packages/app/src/LocalCacheManager.ts
@@ -20,19 +20,20 @@ export default class LocalCacheManager extends CacheManager {
     grouping: string,
   ): Promise<EstimationResult[]> {
     this.cacheLogger.info('Using local cache file...')
-    const estimates = await this.loadEstimates(grouping)
+    const estimates = await this.loadEstimates(grouping, request.subscriptionIds)
     return estimates ? this.filterEstimatesForRequest(request, estimates) : []
   }
 
   async setEstimates(
     estimates: EstimationResult[],
     grouping: string,
+    subscriptionIds?: string,
   ): Promise<void> {
-    const cachedEstimates = await this.loadEstimates(grouping)
+    const cachedEstimates = await this.loadEstimates(grouping, subscriptionIds)
 
     const cacheFile: string = process.env.TEST_MODE
       ? testCachePath
-      : getCacheFileName(grouping)
+      : getCacheFileName(grouping, subscriptionIds)
 
     await this.fileHandle(cacheFile, cachedEstimates.concat(estimates))
   }
@@ -51,11 +52,11 @@ export default class LocalCacheManager extends CacheManager {
     }
   }
 
-  private async loadEstimates(grouping: string): Promise<EstimationResult[]> {
+  private async loadEstimates(grouping: string,subscriptionIds?: string): Promise<EstimationResult[]> {
     let cachedData: EstimationResult[] | any
     const loadedCache = process.env.TEST_MODE
       ? testCachePath
-      : getCacheFileName(grouping)
+      : getCacheFileName(grouping, subscriptionIds)
     try {
       await promises.access(loadedCache)
       const dataStream = await fs.createReadStream(loadedCache)

--- a/packages/app/src/RawRequest.ts
+++ b/packages/app/src/RawRequest.ts
@@ -7,7 +7,8 @@ export interface FootprintEstimatesRawRequest {
   endDate?: string
   region?: string
   ignoreCache?: string
-  groupBy?: string
+  groupBy?: string,
+  subscriptionIds?: string
 }
 
 export interface RecommendationsRawRequest {

--- a/packages/app/src/__tests__/Cache.test.ts
+++ b/packages/app/src/__tests__/Cache.test.ts
@@ -274,7 +274,7 @@ describe('Cache', () => {
       await propertyDescriptor.value(rawRequest)
 
       //assert
-      expect(mockSetEstimates).toHaveBeenCalledWith(computedEstimates, 'day')
+      expect(mockSetEstimates).toHaveBeenCalledWith(computedEstimates, 'day', undefined)
     })
 
     it('should not save into cache when API response contains empty data', async () => {
@@ -345,7 +345,7 @@ describe('Cache', () => {
       //assert
       expect(mockSetEstimates).toHaveBeenCalledWith(
         computedEstimates.concat(buildFootprintEstimates('2020-07-15', 6)),
-        'day',
+        'day', undefined
       )
     })
 

--- a/packages/app/src/__tests__/CreateValidRequest.test.ts
+++ b/packages/app/src/__tests__/CreateValidRequest.test.ts
@@ -27,6 +27,24 @@ describe('CreateValidRequest', () => {
       ignoreCache: false,
     })
   })
+  it('populates subscriptionIds', () => {
+    const input = {
+      startDate: '2020-07-01',
+      endDate: '2020-07-13',
+      region: AWS_REGIONS.US_EAST_1,
+      subscriptionIds: 'sub-1,sub-2'
+    }
+
+    const result = CreateValidFootprintRequest(input)
+
+    expect(result).toEqual({
+      startDate: moment.utc('2020-07-01').toDate(),
+      endDate: moment.utc('2020-07-13').toDate(),
+      region: AWS_REGIONS.US_EAST_1,
+      ignoreCache: false,
+      subscriptionIds: 'sub-1,sub-2'
+    })
+  })
 
   it('ensures the start date is before the end date', () => {
     const input = {

--- a/packages/app/src/__tests__/common/helpers.test.ts
+++ b/packages/app/src/__tests__/common/helpers.test.ts
@@ -73,5 +73,15 @@ describe('common/helpers.ts', () => {
       const cacheFile = getCacheFileName('day')
       expect(cacheFile).toEqual('my-cache-file.day.json')
     })
+
+    it('should use the default filename if no subscriptionIds are present', async () => {
+      const cacheFile = getCacheFileName('day', undefined)
+      expect(cacheFile).toEqual('estimates.cache.day.json')
+    })
+    
+    it('should add subscriptionIds hash if subscriptionIds are present', async () => {
+      const cacheFile = getCacheFileName('day', 'sub-1,sub-2')
+      expect(cacheFile).not.toEqual('estimates.cache.day.json')
+    })
   })
 })

--- a/packages/app/src/common/helpers.ts
+++ b/packages/app/src/common/helpers.ts
@@ -72,12 +72,25 @@ const dateTimeReviver = (key: string, value: string) => {
  *
  * @param grouping Unit of measure that the data will be grouped by
  */
-export function getCacheFileName(grouping: string): string {
+export function getCacheFileName(grouping: string, subscriptionIds?: string): string {
   const cachePrefix = process.env.CCF_CACHE_PATH || 'estimates.cache'
   const existingFileExtension = cachePrefix.lastIndexOf('.json')
+  const subscriptionIdsPart = subscriptionIds === undefined ? '' : getHash(subscriptionIds)
   const prefix =
     existingFileExtension !== -1
       ? cachePrefix.substr(0, existingFileExtension)
       : cachePrefix
-  return `${prefix}.${grouping}.json`
+  return `${prefix}.${grouping}${subscriptionIdsPart}.json`
+}
+
+export function getHash(str: string, seed = 0) {
+  let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+  h1 = Math.imul(h1 ^ (h1>>>16), 2246822507) ^ Math.imul(h2 ^ (h2>>>13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2>>>16), 2246822507) ^ Math.imul(h1 ^ (h1>>>13), 3266489909);
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0)
 }

--- a/packages/azure/src/__tests__/AzureAccount.test.ts
+++ b/packages/azure/src/__tests__/AzureAccount.test.ts
@@ -51,6 +51,7 @@ describe('Azure Account', () => {
     mockListSubscriptions.list.mockReturnValue([
       { subscriptionId: 'sub-1' },
       { subscriptionId: 'sub-2' },
+      { subscriptionId: 'sub-3' },
     ])
 
     const mockEstimates: EstimationResult[] = [
@@ -84,6 +85,7 @@ describe('Azure Account', () => {
       startDate,
       endDate,
       grouping,
+      'sub-1,sub-2'
     )
 
     // then
@@ -128,6 +130,7 @@ describe('Azure Account', () => {
       },
     ]
 
+    expect(getEstimatesSpy).toHaveBeenCalledTimes(2)
     expect(results).toEqual(expectedEstimates)
     expect(getEstimatesSpy).toHaveBeenNthCalledWith(
       2,

--- a/packages/azure/src/application/AzureAccount.ts
+++ b/packages/azure/src/application/AzureAccount.ts
@@ -53,8 +53,9 @@ export default class AzureAccount extends CloudProviderAccount {
     startDate: Date,
     endDate: Date,
     grouping: GroupBy,
+    subscriptionIds?: string,
   ): Promise<EstimationResult[]> {
-    const subscriptions = []
+    let subscriptions = []
     for await (const subscription of this.subscriptionClient.subscriptions.list()) {
       subscriptions.push(subscription)
     }
@@ -66,6 +67,11 @@ export default class AzureAccount extends CloudProviderAccount {
       )
     }
 
+    if (subscriptionIds !== undefined) {
+      const subscriptionArr = subscriptionIds.split(',')
+      subscriptions = subscriptions.filter((sub) =>
+        subscriptionArr.includes(sub.subscriptionId))
+    }
     this.logger.info('Mapping Over Subscriptions and Usage Rows')
     const estimationResults = await Promise.all(
       subscriptions.map(async (subscription: Subscription) => {


### PR DESCRIPTION
## Description of Change
Added ability to specify the footprint requests to specific subscriptionIds (comma separated string) that is sent as a part of the request to the API.

I also needed update the caching so that it does not use the same cache file for different subscriptionIds.

Fixes #828 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

Write a brief but concise description of the changes you have made while also making sure to **link the relevant issue number to this PR** _( e.g. fixes #ISSUE-NUMBER - optional short description)_

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] tests are changed or added
- [ ] yarn test passes 
- [ ] yarn lint has been run (it fails for files that I did not change)
- [ ] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [ ] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] relevant documentation is changed or added

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
