### PR TITLE
[874] Optimize LambdaPolicy by using ManagedPolicy, limit S3 and logs permissions

### DIFF
--- a/cloudformation/ccf-compute-optimizer.yaml
+++ b/cloudformation/ccf-compute-optimizer.yaml
@@ -68,6 +68,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: ComputeOptimizerExportRole
+      ManagedPolicyArns: ["arn:aws:iam::aws:policy/ComputeOptimizerReadOnlyAccess"]
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -88,11 +89,21 @@ Resources:
         Statement:
           - Action: "logs:CreateLogGroup"
             Effect: "Allow"
-            Resource: "*"
+            Resource: !Sub 'arn:aws:logs:*:${AWS::AccountId}:log-group:*'
           - Effect: "Allow"
             Action:
               - "logs:CreateLogStream"
+            Resource: !Sub 'arn:aws:logs:*:${AWS::AccountId}:log-group:*'
+          - Effect: "Allow"
+            Action:
               - "logs:PutLogEvents"
+            Resource: !Sub 'arn:aws:logs:*:${AWS::AccountId}:log-group:*:log-stream:*'
+          - Effect: "Allow"
+            Action:
+              - "compute-optimizer:ExportLambdaFunctionRecommendations"
+              - "compute-optimizer:ExportEC2InstanceRecommendations"
+              - "compute-optimizer:ExportAutoScalingGroupRecommendations"
+              - "compute-optimizer:ExportEBSVolumeRecommendations"
             Resource: "*"
           - Effect: "Allow"
             Action:
@@ -100,21 +111,10 @@ Resources:
               - "xray:PutTelemetryRecords"
             Resource: "*"
           - Action:
-              - "compute-optimizer:*"
-              - "ec2:DescribeInstances"
-              - "ec2:DescribeVolumes"
-              - "lambda:ListFunctions"
-              - "lambda:ListProvisionedConcurrencyConfigs"
-              - "autoscaling:DescribeAutoScalingGroups"
-              - "cloudwatch:GetMetricData"
-              - "organizations:ListAccounts"
-              - "organizations:DescribeOrganization"
-              - "organizations:DescribeAccount"
-              - "organizations:EnableAWSServiceAccess"
-            Effect: "Allow"
-            Resource: "*"
-          - Action:
-              - "s3:*"
+              - "s3:GetBucketPolicyStatus"
+              - "s3:PutObject"
+              - "s3:GetObject"
+              - "s3:GetBucketAcl"
             Effect: "Allow"
             Resource:
               - !Sub 'arn:aws:s3:::${BucketNamePrefix}-*'


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

Fixes #874 
For exportFunction:
- S3 Permissions based on [this](https://docs.aws.amazon.com/compute-optimizer/latest/ug/create-s3-bucket-policy-for-compute-optimizer.htm), which are GetBucketPolicyStatus, PutObject, and GetBucketAcl
- Added  ComputeOptimizerReadOnlyAccess managed policy to simplify cloudformation - https://docs.aws.amazon.com/compute-optimizer/latest/ug/managed-policies.html
- Explicitly define compute-optimizer:Export*Recommendaitons since its not part of the managed policy
- restrict log group/stream creation to within the same AWS Account

relocateFunction:
- S3 getObject is required

@ericksod  we had brief communication on this issue but I'm not sure who the stakeholders are, please tag the relevant people

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [ ] relevant documentation is changed or added

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
