### PR TITLE
#878 Fix CentralBucketPolicy deployment

### DIFF
--- a/cloudformation/ccf-compute-optimizer.yaml
+++ b/cloudformation/ccf-compute-optimizer.yaml
@@ -47,7 +47,7 @@ Resources:
         RestrictPublicBuckets: True
       BucketName: !Ref CentralBucketName
   centralBucketPolicy:
-    DependsOn: centralBucket
+    Condition: CreateCentralBucketCond
     Type: 'AWS::S3::BucketPolicy'
     Properties:
       Bucket: !Ref centralBucket
@@ -56,13 +56,24 @@ Resources:
         Statement:
           - Effect: "Allow"
             Principal:
-              AWS: "arn:aws:iam::${AWS::AccountId}:role/${CCFRoleName}"
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/${CCFRoleName}"
             Action:
               - "s3:ListBucket"
               - "s3:GetObject"
             Resource:
               - !Sub "arn:aws:s3:::${CentralBucketName}"
               - !Sub "arn:aws:s3:::${CentralBucketName}/*"
+          - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
+            Effect: "Deny"
+            Principal: "*"
+            Action:
+              - "s3:*"
+            Resource:
+              - !Sub "arn:aws:s3:::${CentralBucketName}"
+              - !Sub "arn:aws:s3:::${CentralBucketName}/*"
+            Condition:
+              Bool:
+                'aws:SecureTransport': false
   LambdaExecutionRole:
     Condition: USWest2
     Type: AWS::IAM::Role


### PR DESCRIPTION
fixes #878 

Principal was unable to reference AccountId without !Sub

DependsOn wasn't working if centralBucket is not deployed, use Condition instead.

Add AllowSSLRequestsOnly as per # AWS Foundational Security Best Practices

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] git pre-commit hook is successfully executed.

## Notes

© 2021 Thoughtworks, Inc.
