### PR TITLE
Include default GROUP_BY config value in the client package

### DIFF
--- a/.changeset/pink-geese-taste.md
+++ b/.changeset/pink-geese-taste.md
@@ -1,0 +1,5 @@
+---
+'@cloud-carbon-footprint/client': minor
+---
+
+Set default value 'day' for GROUP_BY config parameter

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -33,7 +33,7 @@ const defaultLimitsByGrouping = {
   year: 1,
 }
 
-const groupBy = process.env.REACT_APP_GROUP_BY
+const groupBy = process.env.REACT_APP_GROUP_BY || 'day'
 
 const appConfig: ClientConfig = {
   CURRENT_PROVIDERS: [
@@ -48,8 +48,7 @@ const appConfig: ClientConfig = {
   },
   GROUP_BY: groupBy,
   PAGE_LIMIT:
-    process.env.REACT_APP_PAGE_LIMIT ||
-    defaultLimitsByGrouping[groupBy || 'day'],
+    process.env.REACT_APP_PAGE_LIMIT || defaultLimitsByGrouping[groupBy],
   BASE_URL: process.env.REACT_APP_BASE_URL || '/api',
   MINIMAL_DATE_AGE: process.env.REACT_APP_MINIMAL_DATE_AGE || '0',
   START_DATE: process.env.REACT_APP_START_DATE,


### PR DESCRIPTION
## Description of Change

Fixes memory issues when using the the current client container along with the api container.

The api package seems to hit memory issues when its 'footprint' endpoint is queried without the groupBy parameter. This PR includes a quick fix for the client package which adds a sensible default value ("day" which is also the default in the .env.template file) to the GROUP_BY config param.

## Checklist

- [ x] PR description included and stakeholders cc'd
- [x ] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [x ] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)

## Notes

This is just a quick fix for a memory issue with the api package.

As mentioned [here](https://www.cloudcarbonfootprint.org/docs/performance-considerations#group-by-timestamp-in-queries), the API package's 'footprint' endpoint seems to need the groupBy parameter to avoid performance issues. When calling the endpoint without the param, a warn message is logged that mentions the groupBy parameter will be mandatory in the future - it might be time to make a decision on this.

Also, in the future it might be worth updating the client package to be able to take runtime environment variables that could be fed to the container.

© 2021 Thoughtworks, Inc.
