### PR TITLE
Fix issue where AWS Lambda emissions calculation does not consider processor architecture

### DIFF
--- a/.changeset/fuzzy-pillows-shake.md
+++ b/.changeset/fuzzy-pillows-shake.md
@@ -1,0 +1,5 @@
+---
+'@cloud-carbon-footprint/aws': patch
+---
+
+Correctly calculate emissions for AWS Lambda when using ARM architecture.

--- a/packages/aws/src/__tests__/fixtures/athena.fixtures.ts
+++ b/packages/aws/src/__tests__/fixtures/athena.fixtures.ts
@@ -1351,3 +1351,39 @@ export const athenaMockGetQueryResultsWithGPUInstances: Athena.GetQueryResultsOu
       Rows: [queryResultsHeaders, ...queryResultsDataEighteen],
     },
   }
+
+const queryResultsX86AndARMLambdas = [
+  {
+    Data: [
+      { VarCharValue: '2022-01-01' },
+      { VarCharValue: '123456789' },
+      { VarCharValue: 'us-east-1' },
+      { VarCharValue: 'AWSLambda' },
+      { VarCharValue: 'Lambda-GB-Second' },
+      { VarCharValue: 'seconds' },
+      { VarCharValue: '' },
+      { VarCharValue: '5' },
+      { VarCharValue: '8' },
+    ],
+  },
+  {
+    Data: [
+      { VarCharValue: '2022-01-02' },
+      { VarCharValue: '123456789' },
+      { VarCharValue: 'us-east-1' },
+      { VarCharValue: 'AWSLambda' },
+      { VarCharValue: 'Lambda-GB-Second-ARM' },
+      { VarCharValue: 'Lambda-GB-Second' },
+      { VarCharValue: '' },
+      { VarCharValue: '7' },
+      { VarCharValue: '9' },
+    ],
+  },
+]
+
+export const athenaMockGetQueryResultsWithX86AndARMLambdas: Athena.GetQueryResultsOutput =
+  {
+    ResultSet: {
+      Rows: [queryResultsHeaders, ...queryResultsX86AndARMLambdas],
+    },
+  }

--- a/packages/aws/src/lib/AWSComputeEstimatesBuilder.ts
+++ b/packages/aws/src/lib/AWSComputeEstimatesBuilder.ts
@@ -14,21 +14,17 @@ import {
   AWS_CLOUD_CONSTANTS,
   AWS_EMISSIONS_FACTORS_METRIC_TON_PER_KWH,
 } from '../domain'
-import {
-  GPU_INSTANCES_TYPES,
-  INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING,
-  INSTANCE_TYPE_GPU_PROCESSOR_MAPPING,
-} from './AWSInstanceTypes'
+import { GPU_INSTANCES_TYPES } from './AWSInstanceTypes'
 import CostAndUsageReportsRow from './CostAndUsageReportsRow'
 import RightsizingRecommendation from './Recommendations/Rightsizing/RightsizingTargetRecommendation'
-import { EC2CurrentComputeOptimizerRecommendation } from './Recommendations/ComputeOptimizer'
+import ComputeOptimizerRecommendationWithProcessors from './Recommendations/ComputeOptimizer/ComputeOptimizerRecommendationWithProcessors'
 
 export default class AWSComputeEstimatesBuilder extends FootprintEstimatesDataBuilder {
   constructor(
     rowData:
       | RightsizingRecommendation
       | CostAndUsageReportsRow
-      | EC2CurrentComputeOptimizerRecommendation,
+      | ComputeOptimizerRecommendationWithProcessors,
     computeEstimator: ComputeEstimator,
   ) {
     super(rowData)
@@ -36,14 +32,8 @@ export default class AWSComputeEstimatesBuilder extends FootprintEstimatesDataBu
     this.vCpuHours = rowData.vCpuHours
     this.region = rowData.region
     this.powerUsageEffectiveness = AWS_CLOUD_CONSTANTS.getPUE(this.region)
-    this.computeProcessors = this.getComputeProcessors(
-      rowData.instanceType,
-      INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING,
-    )
-    this.gpuComputeProcessors = this.getComputeProcessors(
-      rowData.instanceType,
-      INSTANCE_TYPE_GPU_PROCESSOR_MAPPING,
-    )
+    this.computeProcessors = rowData.getComputeProcessors()
+    this.gpuComputeProcessors = rowData.getGPUComputeProcessors()
     this.computeConstants = this.getComputeConstants()
     this.computeFootprint = this.getComputeFootprint(
       computeEstimator,

--- a/packages/aws/src/lib/AWSMemoryEstimatesBuilder.ts
+++ b/packages/aws/src/lib/AWSMemoryEstimatesBuilder.ts
@@ -41,10 +41,7 @@ export default class AWSMemoryEstimatesBuilder extends FootprintEstimatesDataBui
     this.usageAmount = rowData.usageAmount
     this.region = rowData.region
     this.powerUsageEffectiveness = AWS_CLOUD_CONSTANTS.getPUE(this.region)
-    this.computeProcessors = this.getComputeProcessors(
-      rowData.instanceType,
-      INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING,
-    )
+    this.computeProcessors = rowData.getComputeProcessors()
     this.memoryUsage = this.getMemoryUsage()
     this.memoryConstants = this.getMemoryConstants()
     this.memoryFootprint = this.getMemoryFootprint(

--- a/packages/aws/src/lib/CostAndUsageReports.ts
+++ b/packages/aws/src/lib/CostAndUsageReports.ts
@@ -318,6 +318,7 @@ export default class CostAndUsageReports {
         )
       case KNOWN_USAGE_UNITS.SECONDS_1:
       case KNOWN_USAGE_UNITS.SECONDS_2:
+      case KNOWN_USAGE_UNITS.LAMBDA_SECONDS:
         // Lambda
         costAndUsageReportRow.vCpuHours =
           costAndUsageReportRow.usageAmount / 3600

--- a/packages/aws/src/lib/CostAndUsageReportsRow.ts
+++ b/packages/aws/src/lib/CostAndUsageReportsRow.ts
@@ -3,7 +3,10 @@
  */
 
 import { Athena } from 'aws-sdk'
-import { BillingDataRow } from '@cloud-carbon-footprint/core'
+import {
+  BillingDataRow,
+  COMPUTE_PROCESSOR_TYPES,
+} from '@cloud-carbon-footprint/core'
 import {
   configLoader,
   containsAny,
@@ -13,6 +16,8 @@ import {
   BURSTABLE_INSTANCE_BASELINE_UTILIZATION,
   EC2_INSTANCE_TYPES,
   GPU_INSTANCES_TYPES,
+  INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING,
+  INSTANCE_TYPE_GPU_PROCESSOR_MAPPING,
   MSK_INSTANCE_TYPES,
   REDSHIFT_INSTANCE_TYPES,
 } from './AWSInstanceTypes'
@@ -161,6 +166,34 @@ export default class CostAndUsageReportsRow extends BillingDataRow {
           usageRow.region,
         )) ||
       AWS_REPLICATION_FACTORS_FOR_SERVICES.DEFAULT()
+    )
+  }
+
+  public getComputeProcessors(): string[] {
+    if (this.serviceName === 'AWSLambda') {
+      if (this.usageType.endsWith('-ARM')) {
+        return [COMPUTE_PROCESSOR_TYPES.AWS_GRAVITON_2]
+      } else {
+        return [COMPUTE_PROCESSOR_TYPES.UNKNOWN]
+      }
+    }
+
+    return (
+      INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING[this.instanceType] || [
+        COMPUTE_PROCESSOR_TYPES.UNKNOWN,
+      ]
+    )
+  }
+
+  public getGPUComputeProcessors(): string[] {
+    if (this.serviceName === 'AWSLambda') {
+      return [COMPUTE_PROCESSOR_TYPES.UNKNOWN]
+    }
+
+    return (
+      INSTANCE_TYPE_GPU_PROCESSOR_MAPPING[this.instanceType] || [
+        COMPUTE_PROCESSOR_TYPES.UNKNOWN,
+      ]
     )
   }
 }

--- a/packages/aws/src/lib/CostAndUsageTypes.ts
+++ b/packages/aws/src/lib/CostAndUsageTypes.ts
@@ -199,6 +199,7 @@ export enum KNOWN_USAGE_UNITS {
   GB_2 = 'GigaBytes',
   SECONDS_1 = 'seconds',
   SECONDS_2 = 'Second',
+  LAMBDA_SECONDS = 'Lambda-GB-Second',
 }
 
 export const AWS_QUERY_GROUP_BY: QUERY_DATE_TYPES = {

--- a/packages/aws/src/lib/Recommendations/ComputeOptimizer/ComputeOptimizerRecommendationWithProcessors.ts
+++ b/packages/aws/src/lib/Recommendations/ComputeOptimizer/ComputeOptimizerRecommendationWithProcessors.ts
@@ -1,0 +1,11 @@
+/*
+ * © 2021 Thoughtworks, Inc.
+ */
+
+import ComputeOptimizerRecommendation from './ComputeOptimizerRecommendation'
+
+export default abstract class ComputeOptimizerRecommendationWithProcessors extends ComputeOptimizerRecommendation {
+  public abstract vCpuHours: number
+  public abstract getComputeProcessors(): string[]
+  public abstract getGPUComputeProcessors(): string[]
+}

--- a/packages/aws/src/lib/Recommendations/ComputeOptimizer/EC2CurrentComputeOptimizerRecommendation.ts
+++ b/packages/aws/src/lib/Recommendations/ComputeOptimizer/EC2CurrentComputeOptimizerRecommendation.ts
@@ -3,9 +3,14 @@
  */
 import { getHoursInMonth } from '@cloud-carbon-footprint/common'
 import { EC2ComputeOptimizerRecommendationData } from './ComputeOptimizerRecommendationData'
-import ComputeOptimizerRecommendation from './ComputeOptimizerRecommendation'
+import {
+  INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING,
+  INSTANCE_TYPE_GPU_PROCESSOR_MAPPING,
+} from '../../AWSInstanceTypes'
+import { COMPUTE_PROCESSOR_TYPES } from '@cloud-carbon-footprint/core'
+import ComputeOptimizerRecommendationWithProcessors from './ComputeOptimizerRecommendationWithProcessors'
 
-export default class EC2CurrentComputeOptimizerRecommendation extends ComputeOptimizerRecommendation {
+export default class EC2CurrentComputeOptimizerRecommendation extends ComputeOptimizerRecommendationWithProcessors {
   public instanceName: string
   public vCpuHours: number
   public instanceType: string
@@ -58,5 +63,21 @@ export default class EC2CurrentComputeOptimizerRecommendation extends ComputeOpt
         vcpus: computeOptimizerRecommendationData.recommendationOptions_3_vcpus,
       },
     ]
+  }
+
+  public getComputeProcessors(): string[] {
+    return (
+      INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING[this.instanceType] || [
+        COMPUTE_PROCESSOR_TYPES.UNKNOWN,
+      ]
+    )
+  }
+
+  public getGPUComputeProcessors(): string[] {
+    return (
+      INSTANCE_TYPE_GPU_PROCESSOR_MAPPING[this.instanceType] || [
+        COMPUTE_PROCESSOR_TYPES.UNKNOWN,
+      ]
+    )
   }
 }

--- a/packages/aws/src/lib/Recommendations/ComputeOptimizer/EC2TargetComputeOptimizerRecommendation.ts
+++ b/packages/aws/src/lib/Recommendations/ComputeOptimizer/EC2TargetComputeOptimizerRecommendation.ts
@@ -6,9 +6,14 @@ import {
   getHoursInMonth,
 } from '@cloud-carbon-footprint/common'
 import { EC2ComputeOptimizerRecommendationData } from './ComputeOptimizerRecommendationData'
-import ComputeOptimizerRecommendation from './ComputeOptimizerRecommendation'
+import {
+  INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING,
+  INSTANCE_TYPE_GPU_PROCESSOR_MAPPING,
+} from '../../AWSInstanceTypes'
+import { COMPUTE_PROCESSOR_TYPES } from '@cloud-carbon-footprint/core'
+import ComputeOptimizerRecommendationWithProcessors from './ComputeOptimizerRecommendationWithProcessors'
 
-export default class EC2TargetComputeOptimizerRecommendation extends ComputeOptimizerRecommendation {
+export default class EC2TargetComputeOptimizerRecommendation extends ComputeOptimizerRecommendationWithProcessors {
   public instanceName: string
   public vCpuHours: number
   public instanceType: string
@@ -65,5 +70,21 @@ export default class EC2TargetComputeOptimizerRecommendation extends ComputeOpti
     this.costSavings = parseFloat(optimalRecommendation.costSavings)
     this.vCpuHours = this.getVCpuHours(this.targetVcpus, this.instanceType)
     this.usageAmount = getHoursInMonth()
+  }
+
+  public getComputeProcessors(): string[] {
+    return (
+      INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING[this.instanceType] || [
+        COMPUTE_PROCESSOR_TYPES.UNKNOWN,
+      ]
+    )
+  }
+
+  public getGPUComputeProcessors(): string[] {
+    return (
+      INSTANCE_TYPE_GPU_PROCESSOR_MAPPING[this.instanceType] || [
+        COMPUTE_PROCESSOR_TYPES.UNKNOWN,
+      ]
+    )
   }
 }

--- a/packages/aws/src/lib/Recommendations/ComputeOptimizer/LambdaCurrentComputeOptimizerRecommendation.ts
+++ b/packages/aws/src/lib/Recommendations/ComputeOptimizer/LambdaCurrentComputeOptimizerRecommendation.ts
@@ -2,10 +2,11 @@
  * © 2021 Thoughtworks, Inc.
  */
 import { LambdaComputeOptimizerRecommendationData } from './ComputeOptimizerRecommendationData'
-import ComputeOptimizerRecommendation from './ComputeOptimizerRecommendation'
 import { getHoursInMonth } from '@cloud-carbon-footprint/common'
+import ComputeOptimizerRecommendationWithProcessors from './ComputeOptimizerRecommendationWithProcessors'
+import { COMPUTE_PROCESSOR_TYPES } from '@cloud-carbon-footprint/core'
 
-export default class LambdaCurrentComputeOptimizerRecommendation extends ComputeOptimizerRecommendation {
+export default class LambdaCurrentComputeOptimizerRecommendation extends ComputeOptimizerRecommendationWithProcessors {
   public functionVersion: string
   public memorySize: string
   public vCpus: string
@@ -61,5 +62,14 @@ export default class LambdaCurrentComputeOptimizerRecommendation extends Compute
 
   public getVcpusForLambda(memorySize: string) {
     return (parseFloat(memorySize) / 1769).toString() //memory(MB) equivalent to 1 vcpu
+  }
+
+  // FIXME: this assumes that the lambda is running on x86, not ARM
+  public getComputeProcessors(): string[] {
+    return [COMPUTE_PROCESSOR_TYPES.UNKNOWN]
+  }
+
+  public getGPUComputeProcessors(): string[] {
+    return [COMPUTE_PROCESSOR_TYPES.UNKNOWN]
   }
 }

--- a/packages/aws/src/lib/Recommendations/ComputeOptimizer/LambdaTargetComputeOptimizerRecommendation.ts
+++ b/packages/aws/src/lib/Recommendations/ComputeOptimizer/LambdaTargetComputeOptimizerRecommendation.ts
@@ -6,9 +6,10 @@ import {
   getHoursInMonth,
   LambdaRecommendationOption,
 } from '@cloud-carbon-footprint/common'
-import ComputeOptimizerRecommendation from './ComputeOptimizerRecommendation'
+import ComputeOptimizerRecommendationWithProcessors from './ComputeOptimizerRecommendationWithProcessors'
+import { COMPUTE_PROCESSOR_TYPES } from '@cloud-carbon-footprint/core'
 
-export default class LambdaTargetComputeOptimizerRecommendation extends ComputeOptimizerRecommendation {
+export default class LambdaTargetComputeOptimizerRecommendation extends ComputeOptimizerRecommendationWithProcessors {
   public functionVersion: string
   public memorySize: string
   public vCpus: string
@@ -65,5 +66,14 @@ export default class LambdaTargetComputeOptimizerRecommendation extends ComputeO
 
   public getVcpusForLambda(memorySize: string) {
     return (parseFloat(memorySize) / 1769).toString() //memory(MB) equivalent to 1 vcpu
+  }
+
+  // FIXME: this assumes that the lambda is running on x86, not ARM
+  public getComputeProcessors(): string[] {
+    return [COMPUTE_PROCESSOR_TYPES.UNKNOWN]
+  }
+
+  public getGPUComputeProcessors(): string[] {
+    return [COMPUTE_PROCESSOR_TYPES.UNKNOWN]
   }
 }

--- a/packages/aws/src/lib/Recommendations/Rightsizing/RightsizingRecommendation.ts
+++ b/packages/aws/src/lib/Recommendations/Rightsizing/RightsizingRecommendation.ts
@@ -7,8 +7,13 @@ import {
 } from 'aws-sdk/clients/costexplorer'
 import { containsAny, getHoursInMonth } from '@cloud-carbon-footprint/common'
 import { AWS_MAPPED_REGION_NAMES_TO_CODES, AWS_REGIONS } from '../../AWSRegions'
-import { BURSTABLE_INSTANCE_BASELINE_UTILIZATION } from '../../AWSInstanceTypes'
+import {
+  BURSTABLE_INSTANCE_BASELINE_UTILIZATION,
+  INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING,
+  INSTANCE_TYPE_GPU_PROCESSOR_MAPPING,
+} from '../../AWSInstanceTypes'
 import { AWS_CLOUD_CONSTANTS } from '../../../domain'
+import { COMPUTE_PROCESSOR_TYPES } from '@cloud-carbon-footprint/core'
 
 export default class RightsizingRecommendation {
   public accountId: string
@@ -48,5 +53,21 @@ export default class RightsizingRecommendation {
 
   public getMappedRegion(region: string): string {
     return AWS_MAPPED_REGION_NAMES_TO_CODES[region] || AWS_REGIONS.UNKNOWN
+  }
+
+  public getComputeProcessors(): string[] {
+    return (
+      INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING[this.instanceType] || [
+        COMPUTE_PROCESSOR_TYPES.UNKNOWN,
+      ]
+    )
+  }
+
+  public getGPUComputeProcessors(): string[] {
+    return (
+      INSTANCE_TYPE_GPU_PROCESSOR_MAPPING[this.instanceType] || [
+        COMPUTE_PROCESSOR_TYPES.UNKNOWN,
+      ]
+    )
   }
 }

--- a/packages/core/src/FootprintEstimatesDataBuilder.ts
+++ b/packages/core/src/FootprintEstimatesDataBuilder.ts
@@ -6,7 +6,6 @@ import {
   CloudConstants,
   FootprintEstimate,
   MemoryUsage,
-  COMPUTE_PROCESSOR_TYPES,
   ComputeUsage,
   StorageUsage,
 } from '.'
@@ -35,18 +34,5 @@ export default abstract class FootprintEstimatesDataBuilder {
 
   protected constructor(init: Partial<FootprintEstimatesDataBuilder>) {
     Object.assign(this, init)
-  }
-
-  public getComputeProcessors(
-    instanceType: string,
-    INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING: {
-      [key: string]: string[]
-    },
-  ): string[] {
-    return (
-      INSTANCE_TYPE_COMPUTE_PROCESSOR_MAPPING[instanceType] || [
-        COMPUTE_PROCESSOR_TYPES.UNKNOWN,
-      ]
-    )
   }
 }


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

Previously, emissions for all lambdas were calculated assuming that they were running on an average x86 processor. This PR adjusts the calculation for lambdas running on ARM processors.


## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- (n/a) relevant documentation is changed or added

## Notes

This was a far more invasive change than I anticipated, and I debated where and how to fix this, so any feedback on how I've gone about this is more than welcome.

© 2021 Thoughtworks, Inc.
