### PR TITLE
Fix issue where getPeriodEndDate could return the incorrect time if the local timezone switched to or from DST during the period

### DIFF
--- a/.changeset/slimy-ladybugs-film.md
+++ b/.changeset/slimy-ladybugs-film.md
@@ -1,0 +1,5 @@
+---
+'@cloud-carbon-footprint/common': patch
+---
+
+Correctly calculate period end date when the local timezone switched into or out of DST during the period

--- a/packages/common/src/helpers/__tests__/helpers.test.ts
+++ b/packages/common/src/helpers/__tests__/helpers.test.ts
@@ -13,9 +13,6 @@ import {
 } from '../helpers'
 
 jest.useFakeTimers()
-jest.mock('moment', () => {
-  return () => jest.requireActual('moment')('2020-04-01T00:00:00.000Z')
-})
 
 describe('Helpers', () => {
   it('contains any', () => {
@@ -67,7 +64,10 @@ describe('Helpers', () => {
       [GroupBy.quarter, new Date('2020-07-01T00:59:59.000Z')],
       [GroupBy.year, new Date('2021-03-31T23:59:59.000Z')],
     ]).it('should get period end date for %s', (grouping, expectedResult) => {
-      const result = getPeriodEndDate(new Date(), grouping)
+      const result = getPeriodEndDate(
+        new Date('2020-04-01T00:00:00.000Z'),
+        grouping,
+      )
 
       expect(result).toEqual(expectedResult)
     })

--- a/packages/common/src/helpers/helpers.ts
+++ b/packages/common/src/helpers/helpers.ts
@@ -28,19 +28,18 @@ export const getHoursInMonth = (): number => {
   return moment().utc().daysInMonth() * 24
 }
 
-//01/01- 00 --01/01 -23-59-59
-
 export const getPeriodEndDate = (startDate: Date, grouping: GroupBy): Date => {
   const periodGrouping: { [key: string]: Date } = {
-    day: moment(startDate).add(1, 'd').subtract(1, 's').toDate(),
-    week: moment(startDate).add(1, 'w').subtract(1, 's').toDate(),
-    month: moment(startDate).add(1, 'M').subtract(1, 's').toDate(),
-    quarter: moment(startDate)
+    day: moment.utc(startDate).add(1, 'd').subtract(1, 's').toDate(),
+    week: moment.utc(startDate).add(1, 'w').subtract(1, 's').toDate(),
+    month: moment.utc(startDate).add(1, 'M').subtract(1, 's').toDate(),
+    quarter: moment
+      .utc(startDate)
       .add(1, 'Q')
       .add(1, 'h')
       .subtract(1, 's')
       .toDate(),
-    year: moment(startDate).add(1, 'y').subtract(1, 's').toDate(),
+    year: moment.utc(startDate).add(1, 'y').subtract(1, 's').toDate(),
   }
 
   return periodGrouping[grouping]


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

`getPeriodEndDate`'s tests were failing for me on my laptop, and this revealed a bug in its logic: period calculations were being done in the local timezone, rather than in a timezone-independent manner.

(I'm in the Australia/Melbourne timezone and we had a DST transition on April 5, 2020.)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] (n/a) relevant documentation is changed or added


© 2021 Thoughtworks, Inc.
