### PR TITLE
[CCF-651] Show error message in error page UI and client console 

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -20,10 +20,12 @@ interface AppProps {
   config?: ClientConfig
 }
 export function App({ config = loadConfig() }: AppProps): ReactElement {
+  const [errorMessage, setErrorMessage] = useState('')
   const navigate = useNavigate()
   const onApiError = useCallback(
     (e: AxiosError) => {
       console.error(e)
+      setErrorMessage(e.message)
       navigate('/error', { state: formatAxiosError(e) })
     },
     [navigate],
@@ -72,7 +74,10 @@ export function App({ config = loadConfig() }: AppProps): ReactElement {
               <RecommendationsPage config={config} onApiError={onApiError} />
             }
           />
-          <Route path="/error" element={<ErrorPage />} />
+          <Route
+            path="/error"
+            element={<ErrorPage errorMessage={errorMessage} />}
+          />
         </Routes>
       </Container>
     </>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -25,7 +25,7 @@ export function App({ config = loadConfig() }: AppProps): ReactElement {
   const onApiError = useCallback(
     (e: AxiosError) => {
       console.error(e)
-      setErrorMessage(e.message)
+      setErrorMessage(e.response.data)
       navigate('/error', { state: formatAxiosError(e) })
     },
     [navigate],

--- a/packages/client/src/layout/ErrorPage/ErrorPage.test.tsx
+++ b/packages/client/src/layout/ErrorPage/ErrorPage.test.tsx
@@ -22,4 +22,11 @@ describe('ErrorPage', () => {
     const { getByTestId } = render(<ErrorPage />)
     expect(getByTestId('error-page')).toBeInTheDocument()
   })
+
+  test('shows error message on the error page', () => {
+    const { getByTestId } = render(
+      <ErrorPage errorMessage={'test-error-message'} />,
+    )
+    expect(getByTestId('error-message')).toHaveTextContent('test-error-message')
+  })
 })

--- a/packages/client/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/client/src/layout/ErrorPage/ErrorPage.tsx
@@ -46,6 +46,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     errorMessage: {
       fontSize: '18px',
+      textAlign: 'center',
     },
   }),
 )
@@ -64,10 +65,13 @@ export const formatAxiosError = (e: AxiosError): ErrorState => {
     : DEFAULT_ERROR
 }
 
-const ErrorPage = (): ReactElement => {
+interface ErrorPageProps {
+  errorMessage?: string
+}
+
+const ErrorPage = (props: ErrorPageProps): ReactElement<ErrorPageProps> => {
   const location = useLocation()
   const { statusText, status } = (location.state as ErrorState) ?? DEFAULT_ERROR
-
   const classes = useStyles()
 
   return (
@@ -84,8 +88,10 @@ const ErrorPage = (): ReactElement => {
         <h1 className={classes.errorStatus}>
           {status} {statusText}
         </h1>
-        <div className={classes.errorMessage}>
-          Something has gone wrong, please try again later
+        <div data-testid="error-message" className={classes.errorMessage}>
+          {props.errorMessage
+            ? props.errorMessage
+            : 'Something has gone wrong, Please try again later'}
         </div>
       </div>
     </Grid>

--- a/packages/client/src/utils/hooks/EmissionFactorServiceHook.ts
+++ b/packages/client/src/utils/hooks/EmissionFactorServiceHook.ts
@@ -40,6 +40,7 @@ const useRemoteEmissionService = (
           setData(res.data)
         }
       } catch (e) {
+        console.error(e.message, e)
         setError(e)
       } finally {
         if (_isMounted.current) {

--- a/packages/client/src/utils/hooks/FootprintServiceHook.ts
+++ b/packages/client/src/utils/hooks/FootprintServiceHook.ts
@@ -74,6 +74,7 @@ const useRemoteFootprintService = (
           skip += params.limit
         }
       } catch (e) {
+        console.error(e.message, e)
         setError(e)
       } finally {
         setData(estimates)

--- a/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
+++ b/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
@@ -41,6 +41,7 @@ const useRemoteRecommendationsService = (
           : await axios.get(`${params.baseUrl}/recommendations`)
         setData(res.data)
       } catch (e) {
+        console.error(e.message, e)
         setError(e)
       } finally {
         setTimeout(() => setLoading(false), params.minLoadTimeMs ?? 1000)

--- a/packages/create-app/templates/default-app/packages/client/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/client/src/App.tsx
@@ -20,10 +20,12 @@ interface AppProps {
   config?: ClientConfig
 }
 export function App({ config = loadConfig() }: AppProps): ReactElement {
+    const [ errorMessage, setErrorMessage] = useState('')
   const navigate = useNavigate()
   const onApiError = useCallback(
     (e: AxiosError) => {
       console.error(e)
+      setErrorMessage(e.message)
       navigate('/error', { state: formatAxiosError(e) })
     },
     [navigate],
@@ -72,7 +74,7 @@ export function App({ config = loadConfig() }: AppProps): ReactElement {
               <RecommendationsPage config={config} onApiError={onApiError} />
             }
           />
-          <Route path="/error" element={<ErrorPage />} />
+          <Route path="/error" element={<ErrorPage errorMessage={ errorMessage } />} />
         </Routes>
       </Container>
     </>

--- a/packages/create-app/templates/default-app/packages/client/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/client/src/App.tsx
@@ -25,7 +25,7 @@ export function App({ config = loadConfig() }: AppProps): ReactElement {
   const onApiError = useCallback(
     (e: AxiosError) => {
       console.error(e)
-      setErrorMessage(e.message)
+      setErrorMessage(e.response.data)
       navigate('/error', { state: formatAxiosError(e) })
     },
     [navigate],

--- a/packages/create-app/templates/default-app/packages/client/src/utils/hooks/EmissionFactorServiceHook.ts
+++ b/packages/create-app/templates/default-app/packages/client/src/utils/hooks/EmissionFactorServiceHook.ts
@@ -40,6 +40,7 @@ const useRemoteEmissionService = (
           setData(res.data)
         }
       } catch (e) {
+        console.error(e.message, e)
         setError(e)
       } finally {
         if (_isMounted.current) {

--- a/packages/create-app/templates/default-app/packages/client/src/utils/hooks/FootprintServiceHook.ts
+++ b/packages/create-app/templates/default-app/packages/client/src/utils/hooks/FootprintServiceHook.ts
@@ -74,6 +74,7 @@ const useRemoteFootprintService = (
           skip += params.limit
         }
       } catch (e) {
+        console.error(e.message, e)
         setError(e)
       } finally {
         setData(estimates)

--- a/packages/create-app/templates/default-app/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
+++ b/packages/create-app/templates/default-app/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
@@ -41,6 +41,7 @@ const useRemoteRecommendationsService = (
           : await axios.get(`${params.baseUrl}/recommendations`)
         setData(res.data)
       } catch (e) {
+        console.error(e.message, e)
         setError(e)
       } finally {
         setTimeout(() => setLoading(false), params.minLoadTimeMs ?? 1000)


### PR DESCRIPTION
## Description of Change

Error messages will be shown in client side logs and the same message will be shown in the UI of the error page.
fixes https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/651

@4upz @ericksod 

## Checklist

- [X] PR description included and stakeholders cc'd
- [X] tests are changed or added
- [X] yarn test passes
- [X] yarn lint has been run
- [X] git pre-commit hook is successfully executed

## Notes

This PR also takes care of showing the error message in error page UI

© 2021 Thoughtworks, Inc.
