### PR TITLE
[CCF-949] Improve test cases for error page

### DIFF
--- a/packages/client/src/layout/ErrorPage/ErrorPage.test.tsx
+++ b/packages/client/src/layout/ErrorPage/ErrorPage.test.tsx
@@ -21,6 +21,8 @@ describe('ErrorPage', () => {
   test('renders when there is an error', () => {
     const { getByTestId } = render(<ErrorPage />)
     expect(getByTestId('error-page')).toBeInTheDocument()
+    expect(getByTestId('error-page')).toHaveTextContent('internal error')
+    expect(getByTestId('error-page')).toHaveTextContent('500')
   })
 
   test('shows error message on the error page', () => {


### PR DESCRIPTION
## Description of Change
Imporve the test cases for error page

In the current implementation of Errorpage.test.tsx, the test case renders when there is an error is checking only if the error-page is rendered. Improved the test case to check what is displayed in this error page. Checked for the status text and the status code. 

fixes #949 

@ericksod @4upz 
## Checklist

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run


© 2021 Thoughtworks, Inc.
