### PR TITLE
#757 Fixed the card title overlapping issue on mobile screen for microsite

### DIFF
--- a/microsite/src/components/valuePropStyles.module.css
+++ b/microsite/src/components/valuePropStyles.module.css
@@ -8,10 +8,17 @@
   }
 }
 
+
 .valuePropCard {
   flex-basis: 100%;
-  margin: 1rem;
+  margin: 1rem 0;
   padding-bottom: 2rem;
+}
+
+@media screen and (min-width: 900px) {
+  .valuePropCard {
+    margin: 1rem;
+  }
 }
 
 @media screen and (max-width: 1280px) {
@@ -29,7 +36,6 @@
 .valuePropCardHeaderContainer {
   display: flex;
   align-items: flex-start;
-  height: 5rem;
   margin-top: 1rem;
 }
 
@@ -56,6 +62,13 @@
 
   .valuePropCardHeaderContainer {
     height: 4rem;
+  }
+}
+
+@media screen and (min-width: 1281px) {
+
+  .valuePropCardHeaderContainer {
+    height: 6rem;
   }
 }
 

--- a/packages/aws/README.md
+++ b/packages/aws/README.md
@@ -1,4 +1,4 @@
-# @cloud-carbon-footprint/core
+# @cloud-carbon-footprint/aws
 
 This package provides the core logic to get cloud usage data and estimate energy and carbon emissions from Amazon Web Services.
 

--- a/packages/azure/README.md
+++ b/packages/azure/README.md
@@ -1,4 +1,4 @@
-# @cloud-carbon-footprint/core
+# @cloud-carbon-footprint/azure
 
 This package provides the core logic to get cloud usage data and estimate energy and carbon emissions from Microsoft Azure.
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,4 +1,4 @@
-# @cloud-carbon-footprint/core
+# @cloud-carbon-footprint/common
 
 This package provides the common functionality to be shared among other cloud carbon footprint packages.
 

--- a/packages/gcp/README.md
+++ b/packages/gcp/README.md
@@ -1,4 +1,4 @@
-# @cloud-carbon-footprint/core
+# @cloud-carbon-footprint/gcp
 
 This package provides the core logic to get cloud usage data and estimate energy and carbon emissions from Google Cloud Platform.
 


### PR DESCRIPTION
## Description of Change

#757  - Fixed the card title overlapping issue by removing the fixed height from valuePropCardsContainer on mobile as the cards are vertically stacked and added 6rem fixed height for desktop to support 3 lines of text.



## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included 
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.

## Notes

Additional information relevant to the changes.

Refer below screenshots after the fix.

<img width="453" alt="image" src="https://user-images.githubusercontent.com/501794/198500182-c1d3cebe-31a1-45b1-a9d5-d7929e86c6b0.png">
<img width="489" alt="image" src="https://user-images.githubusercontent.com/501794/198500203-29cb3475-1e01-4e97-a1dd-8c14006197b1.png">
<img width="455" alt="image" src="https://user-images.githubusercontent.com/501794/198500231-ead0da38-7969-46f6-ac52-b63dde6bd1b2.png">
<img width="842" alt="image" src="https://user-images.githubusercontent.com/501794/198500268-fc2d83bf-6959-43b4-8d64-41681d58d104.png">
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/501794/198500287-1af15426-1280-470e-80ae-2845714660d3.png">



© 2021 Thoughtworks, Inc.
