### PR TITLE
[#818] Integration tests added to CI

### DIFF
--- a/.changeset/weak-snakes-tie.md
+++ b/.changeset/weak-snakes-tie.md
@@ -1,0 +1,6 @@
+---
+'@cloud-carbon-footprint/app': patch
+'@cloud-carbon-footprint/integration-tests': patch
+---
+
+Updates to get integration tests running locally and on CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,9 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -f packages/aws/coverage/* -F aws
           bash <(curl -s https://codecov.io/bash) -f packages/gcp/coverage/* -F gcp
           bash <(curl -s https://codecov.io/bash) -f packages/azure/coverage/* -F azure
-  #      - name: integration tests
-  #        run: yarn test:integration
+      - name: integration tests
+        run: yarn test:integration
+        continue-on-error: true # Temporarily allow continue on failure till we've seen the tests consistently pass on CI
   build:
     needs: lint-test
     runs-on: ubuntu-latest

--- a/packages/app/src/App.ts
+++ b/packages/app/src/App.ts
@@ -45,7 +45,9 @@ export default class App {
     const AWS = config.AWS
     const GCP = config.GCP
     const AZURE = config.AZURE
-
+    if (process.env.TEST_MODE) {
+      return []
+    }
     if (request.region) {
       const estimatesForAccounts: EstimationResult[][] = []
       for (const account of AWS.accounts) {

--- a/packages/integration-tests/.testcaferc.json
+++ b/packages/integration-tests/.testcaferc.json
@@ -5,6 +5,8 @@
   "src": "tests/*test.js",
   "browsers": ["chrome:headless"],
   "concurrency": 3,
+  "selectorTimeout": 5000,
+  "assertionTimeout": 5000,
   "appCommand": "yarn start",
   "screenshots": {
     "takeOnFails": true

--- a/packages/integration-tests/tests/app.test.js
+++ b/packages/integration-tests/tests/app.test.js
@@ -5,12 +5,12 @@
 import waitOn from 'wait-on'
 import page from './page-model'
 
-fixture`Cloud Carbon Footprint`.page`http://localhost:3000/`
+fixture`Cloud Carbon Footprint`.page`http://127.0.0.1:3000/`
   .before(async () => {
     await waitOn({
       resources: [
-        'http://localhost:3000/',
-        'http://localhost:4000/api/healthz',
+        'http://127.0.0.1:3000/',
+        'http://127.0.0.1:4000/api/healthz',
       ],
     })
   })

--- a/packages/integration-tests/tests/app.test.js
+++ b/packages/integration-tests/tests/app.test.js
@@ -75,6 +75,7 @@ test('carbon equivalency component displays each option when clicked', async (t)
 test('emissions breakdown component displays each bar chart when selected', async (t) => {
   // Maximize the window in orde for all DOM elements to be visible.
   // For some reason this stops this test failing, and can help with debugging.
+  // In headless mode, issues have been noted that can be resolved by resizing window: https://github.com/DevExpress/testcafe/issues/6739
   await t.maximizeWindow()
   //sort by account
   await t.click(page.dropDownSelector)
@@ -87,6 +88,7 @@ test('emissions breakdown component displays each bar chart when selected', asyn
   await t.expect(page.selected.withText('computeEngine').exists).ok() //todo: minimize dataset-specific selectors
 
   //sort by region
+  await t.maximizeWindow()
   await t.click(page.dropDownSelector)
   await t.click(page.regionSelection)
   await t.expect(page.selected.withText('us-east-1').exists).ok() //todo: minimize dataset-specific selectors

--- a/packages/integration-tests/tests/recommendations.test.js
+++ b/packages/integration-tests/tests/recommendations.test.js
@@ -6,10 +6,10 @@ import waitOn from 'wait-on'
 import page from './page-model'
 const getLocation = ClientFunction(() => document.location.href)
 
-fixture`Cloud Carbon Footprint Recommendations`.page`http://localhost:3000/`
+fixture`Cloud Carbon Footprint Recommendations`.page`http://127.0.0.1:3000/`
   .before(async () => {
     await waitOn({
-      resources: ['http://localhost:3000/'],
+      resources: ['http://127.0.0.1:3000/'],
     })
   })
   .beforeEach(async (t) => {


### PR DESCRIPTION
## Description of Change

Issue https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/818 changes

1. assertionTimeout and  selectorTimeout set to 5 seconds instead of default 3 seconds
2. added step in CI to run integration tests (With ContinueOnError = true, so that we can monitor tests to ensure they pass consistently without disrupting development effort. Then we can remove this flag.

Issue https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/832 changes: Local hanging issue resolved based on discussion here https://github.com/jeffbski/wait-on/issues/116

Issue https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/959 changes: Needed mock data to be returned in the emissions API, using TEST_MODE flag to know if mocking is needed

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [x] relevant documentation is changed or added

## Notes

- Issues covered in this PR:
       https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/818
       https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/832
       https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/959
- Separately have created an issue to enhance the integration-tests to not use the TEST_MODE flag:
       https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/959

© 2021 Thoughtworks, Inc.
