### PR TITLE
[#550] refactors useKilograms to an enum for Co2e unit

### DIFF
--- a/packages/client/src/Types.ts
+++ b/packages/client/src/Types.ts
@@ -56,7 +56,7 @@ export type FilterBarProps = {
   filters: Filters
   setFilters: Dispatch<SetStateAction<Filters>>
   filterOptions: FilterOptions
-  setUseKilograms?: (boolean) => void
+  setCo2eUnit?: Dispatch<SetStateAction<Co2eUnit>>
 }
 
 export interface Page<T> {
@@ -122,7 +122,7 @@ export type ComparisonItem = {
 
 export type RecommendationRow = RecommendationResult & {
   id: number
-  useKilograms: boolean
+  co2eUnit: Co2eUnit
 }
 
 export type EmissionsAndRecommendationResults = {
@@ -171,4 +171,9 @@ export const unknownOptionTypes: UnknownTypesMapping = {
   [DropdownFilterOptions.ACCOUNTS]: UnknownTypes.UNKNOWN_ACCOUNT,
   [DropdownFilterOptions.SERVICES]: UnknownTypes.UNKNOWN_SERVICE,
   [DropdownFilterOptions.REGIONS]: UnknownTypes.UNKNOWN_REGION,
+}
+
+export enum Co2eUnit {
+  Kilograms = 'Kilograms',
+  MetricTonnes = 'MetricTonnes',
 }

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsFilterBar/RecommendationsFilterBar.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsFilterBar/RecommendationsFilterBar.tsx
@@ -2,8 +2,13 @@
  * © 2021 Thoughtworks, Inc.
  */
 
-import React, { FunctionComponent, ReactElement } from 'react'
-import { DropdownOption, FilterBarProps, FilterOptions } from '../../../Types'
+import React, { FunctionComponent, ReactElement, useCallback } from 'react'
+import {
+  Co2eUnit,
+  DropdownOption,
+  FilterBarProps,
+  FilterOptions,
+} from '../../../Types'
 import {
   ALL_ACCOUNTS_DROPDOWN_OPTION,
   ALL_RECOMMENDATION_TYPES_DROPDOWN_OPTION,
@@ -22,7 +27,7 @@ const RecommendationsFilterBar: FunctionComponent<FilterBarProps> = ({
   filters,
   setFilters,
   filterOptions,
-  setUseKilograms,
+  setCo2eUnit,
 }): ReactElement => {
   const getFilterOptions = (): FilterOptions => {
     const allAccountDropdownOptions = buildAndOrderDropdownOptions(
@@ -63,6 +68,13 @@ const RecommendationsFilterBar: FunctionComponent<FilterBarProps> = ({
     }
   }
 
+  const toggleUnit = useCallback(
+    (useKilograms: boolean) => {
+      setCo2eUnit(useKilograms ? Co2eUnit.Kilograms : Co2eUnit.MetricTonnes)
+    },
+    [setCo2eUnit],
+  )
+
   const filterComponents = [
     CloudProviderFilter,
     AccountFilter,
@@ -77,7 +89,7 @@ const RecommendationsFilterBar: FunctionComponent<FilterBarProps> = ({
   }
 
   const suffixComponents = (
-    <Toggle label="CO2e Units" handleToggle={setUseKilograms} />
+    <Toggle label="CO2e Units" handleToggle={toggleUnit} />
   )
 
   return (

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsPage.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsPage.tsx
@@ -12,6 +12,7 @@ import { ErrorState } from '../../layout/ErrorPage/ErrorPage'
 import { useRecommendationData } from '../../utils/hooks/RecommendationsDataHook'
 import { ClientConfig } from '../../Config'
 import loadConfig from '../../ConfigLoader'
+import { Co2eUnit } from '../../Types'
 
 interface RecommendationsPageProps {
   onApiError?: (e: ErrorState) => void
@@ -24,7 +25,7 @@ const RecommendationsPage = ({
 }): ReactElement<RecommendationsPageProps> => {
   const classes = useStyles()
 
-  const [useKilograms, setUseKilograms] = useState(false)
+  const [co2eUnit, setCo2eUnit] = useState(Co2eUnit.MetricTonnes)
 
   const recommendations = useRecommendationData({
     baseUrl: config.BASE_URL,
@@ -41,14 +42,14 @@ const RecommendationsPage = ({
     <div className={classes.pageContainer}>
       <RecommendationsFilterBar
         {...recommendations.filterBarProps}
-        setUseKilograms={setUseKilograms}
+        setCo2eUnit={setCo2eUnit}
       />
       <div className={classes.boxContainer}>
         <Grid container spacing={3}>
           <RecommendationsTable
             emissionsData={recommendations.filteredEmissionsData}
             recommendations={recommendations.filteredRecommendationData}
-            useKilograms={useKilograms}
+            co2eUnit={co2eUnit}
           />
         </Grid>
       </div>

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsSidePanel/RecommendationsSidePanel.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsSidePanel/RecommendationsSidePanel.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render } from '@testing-library/react'
+import { Co2eUnit } from 'src/Types'
 import { mockRecommendationData } from '../../../utils/data'
 import RecommendationsSidePanel from './RecommendationsSidePanel'
 
@@ -11,7 +12,7 @@ describe('Recommendations Side Panel', () => {
     ...mockRecommendationData[0],
     id: 0,
     accountId: 'test-account-1-id',
-    useKilograms: false,
+    co2eUnit: Co2eUnit.MetricTonnes,
   }
   it('Renders a side panel titled "Recommendation Details"', () => {
     const { getByTestId } = render(

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsSidePanel/RecommendationsSidePanel.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsSidePanel/RecommendationsSidePanel.tsx
@@ -12,6 +12,7 @@ import {
   tableFormatNearZero,
   tableFormatRawCo2e,
 } from '../../../utils/helpers/transformData'
+import { co2eUnitLabel } from '../../../utils/helpers'
 
 export type RecommendationsSidePanelProps = {
   recommendation: RecommendationRow
@@ -80,11 +81,9 @@ const RecommendationsSidePanel: FunctionComponent<
         />
         <RecommendationsPanelColumn
           label="CO2e Savings"
-          subLabel={
-            recommendation.useKilograms ? '(kilograms)' : '(metric tons)'
-          }
+          subLabel={`(${co2eUnitLabel[recommendation.co2eUnit]})`}
           content={tableFormatRawCo2e(
-            recommendation.useKilograms,
+            recommendation.co2eUnit,
             recommendation.co2eSavings,
           )}
         />

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/Forecast/Forecast.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/Forecast/Forecast.test.tsx
@@ -6,11 +6,12 @@ import React from 'react'
 import { render, within } from '@testing-library/react'
 import { ServiceData } from '@cloud-carbon-footprint/common'
 import {
-  mockRecommendationData,
   mockDataWithLargeNumbers,
   mockDataWithSmallNumbers,
+  mockRecommendationData,
 } from '../../../../utils/data'
 import Forecast, { ForecastProps } from './Forecast'
+import { Co2eUnit } from '../../../../Types'
 
 describe('Forecast', () => {
   const emissionsData: ServiceData[] =
@@ -18,7 +19,7 @@ describe('Forecast', () => {
   const testProps: ForecastProps = {
     emissionsData,
     recommendations: mockRecommendationData,
-    useKilograms: false,
+    co2eUnit: Co2eUnit.MetricTonnes,
   }
 
   it('should render the title', () => {

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/Forecast/Forecast.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/Forecast/Forecast.tsx
@@ -19,21 +19,23 @@ import {
 } from '../../../../utils/helpers'
 import ForecastCard from '../ForecastCard'
 import ForecastEquivalencyCard from '../ForecastEquivalencyCard'
+import { Co2eUnit } from '../../../../Types'
+import { co2eUnitMultiplier } from '../../../../utils/helpers/units'
 
 export type ForecastProps = {
   emissionsData: ServiceData[]
   recommendations: RecommendationResult[]
-  useKilograms: boolean
+  co2eUnit: Co2eUnit
 }
 
 const Forecast: FunctionComponent<ForecastProps> = ({
   emissionsData,
   recommendations,
-  useKilograms,
+  co2eUnit,
 }): ReactElement => {
   const classes = useStyles()
 
-  const forecastMultiplier = useKilograms ? 1000 : 1
+  const forecastMultiplier = co2eUnitMultiplier[co2eUnit]
 
   const sumCurrentCo2e = sumEstimates(emissionsData, 'co2e')
   const sumCurrentCost = sumEstimates(emissionsData, 'cost')
@@ -86,7 +88,7 @@ const Forecast: FunctionComponent<ForecastProps> = ({
           title="Last 30 Day Total"
           co2eSavings={currentCo2eFormatted}
           costSavings={currentCostFormatted}
-          useKilograms={useKilograms}
+          co2eUnit={co2eUnit}
           id="last-thirty-day-total"
         />
         <ForwardIcon className={classes.icon} />
@@ -96,7 +98,7 @@ const Forecast: FunctionComponent<ForecastProps> = ({
           costSavings={projectedCostFormatted}
           co2ePercentChange={co2ePercentChange}
           costPercentChange={costPercentChange}
-          useKilograms={useKilograms}
+          co2eUnit={co2eUnit}
           id="projected-thirty-day-total"
         />
         <div className={clsx(classes.icon, classes.equalSign)}>=</div>

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/ForecastCard/ForecastCard.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/ForecastCard/ForecastCard.test.tsx
@@ -5,6 +5,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import ForecastCard from './ForecastCard'
 import each from 'jest-each'
+import { Co2eUnit } from '../../../../Types'
 
 describe('Forecast Card', () => {
   it('should render the card', () => {
@@ -51,7 +52,7 @@ describe('Forecast Card', () => {
         title="Title"
         co2eSavings="1"
         costSavings="1"
-        useKilograms={true}
+        co2eUnit={Co2eUnit.Kilograms}
         id="test"
       />,
     )
@@ -65,7 +66,7 @@ describe('Forecast Card', () => {
         title="Title"
         co2eSavings="9"
         costSavings="1"
-        useKilograms={false}
+        co2eUnit={Co2eUnit.MetricTonnes}
         id="test"
       />,
     )
@@ -83,7 +84,6 @@ describe('Forecast Card', () => {
           costSavings="1"
           co2ePercentChange={25}
           costPercentChange={null}
-          useKilograms={false}
         />,
       )
 
@@ -112,7 +112,7 @@ describe('Forecast Card', () => {
             title="Title"
             co2eSavings="9"
             costSavings="1"
-            useKilograms={false}
+            co2eUnit={Co2eUnit.MetricTonnes}
             {...percentageProps}
           />,
         )

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/ForecastCard/ForecastCard.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/ForecastCard/ForecastCard.tsx
@@ -8,6 +8,8 @@ import { Card, Divider, Typography } from '@material-ui/core'
 import Tooltip from '../../../../common/Tooltip'
 import useStyles from './forecastCardStyles'
 import PercentBadge from '../PercentBadge'
+import { Co2eUnit } from '../../../../Types'
+import { co2eUnitLabel } from '../../../../utils/helpers'
 
 export type ForecastCardProps = {
   title: string
@@ -15,7 +17,7 @@ export type ForecastCardProps = {
   costSavings: string
   co2ePercentChange?: number
   costPercentChange?: number
-  useKilograms?: boolean
+  co2eUnit?: Co2eUnit
   id: string
 }
 
@@ -25,7 +27,7 @@ const ForecastCard: FunctionComponent<ForecastCardProps> = ({
   costSavings,
   co2ePercentChange,
   costPercentChange,
-  useKilograms,
+  co2eUnit = Co2eUnit.MetricTonnes,
   id,
 }) => {
   const classes = useStyles({ co2ePercentChange, costPercentChange })
@@ -64,7 +66,7 @@ const ForecastCard: FunctionComponent<ForecastCardProps> = ({
             className={classes.unitsText}
             data-testid={`unit-of-measure-${id}`}
           >
-            {useKilograms ? 'Kilograms CO2e' : 'Metric Tons CO2e'}
+            {co2eUnitLabel[co2eUnit]} CO2e
           </Typography>
           {hasCo2ePercentChange && <PercentBadge amount={co2ePercentChange} />}
         </div>

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
@@ -2,11 +2,11 @@
  * © 2021 Thoughtworks, Inc.
  */
 
-import { fireEvent, render, within, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import each from 'jest-each'
 import moment from 'moment'
 import { EstimationResult } from '@cloud-carbon-footprint/common'
-import { ServiceResult } from '../../../Types'
+import { Co2eUnit, ServiceResult } from '../../../Types'
 import {
   generateEstimations,
   mockData,
@@ -29,7 +29,7 @@ const testProps = {
   ),
   recommendations: [],
   handleRowClick: jest.fn(),
-  useKilograms: false,
+  co2eUnit: Co2eUnit.MetricTonnes,
 }
 
 describe('Recommendations Table', () => {
@@ -243,7 +243,7 @@ describe('Recommendations Table', () => {
               kilowattHourSavings: null,
             },
           ]}
-          useKilograms={false}
+          co2eUnit={Co2eUnit.MetricTonnes}
         />,
       )
 
@@ -290,7 +290,7 @@ describe('Recommendations Table', () => {
               kilowattHourSavings: null,
             },
           ]}
-          useKilograms={true}
+          co2eUnit={Co2eUnit.Kilograms}
         />,
       )
 
@@ -328,7 +328,7 @@ describe('Recommendations Table', () => {
       <RecommendationsTable
         {...testProps}
         recommendations={mockRecommendations}
-        useKilograms={true}
+        co2eUnit={Co2eUnit.Kilograms}
       />,
     )
 
@@ -386,24 +386,24 @@ describe('Recommendations Table', () => {
     })
 
     const searchedRecommendationsRows = [
-      ['test-b', true, 1, false],
-      ['AWS', true, 2, false],
-      ['us-west-1', true, 1, false],
-      ['Modify', true, 1, false],
-      [2.539, true, 1, false],
-      [2539, true, 1, true],
-      ['pizza', undefined, 0, false],
-      [6.2, undefined, 0, false],
+      ['test-b', true, 1, Co2eUnit.MetricTonnes],
+      ['AWS', true, 2, Co2eUnit.MetricTonnes],
+      ['us-west-1', true, 1, Co2eUnit.MetricTonnes],
+      ['Modify', true, 1, Co2eUnit.MetricTonnes],
+      [2.539, true, 1, Co2eUnit.MetricTonnes],
+      [2539, true, 1, Co2eUnit.Kilograms],
+      ['pizza', undefined, 0, Co2eUnit.MetricTonnes],
+      [6.2, undefined, 0, Co2eUnit.MetricTonnes],
     ]
 
     each(searchedRecommendationsRows).it(
       'should filter according to search bar value %s',
-      (searchValue, expectedResult, rowsLength, useKilograms) => {
+      (searchValue, expectedResult, rowsLength, co2eUnit) => {
         const { getByRole, getAllByRole, getByLabelText } = render(
           <RecommendationsTable
             {...testProps}
             recommendations={mockRecommendationData}
-            useKilograms={useKilograms}
+            co2eUnit={co2eUnit}
           />,
         )
 

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.tsx
@@ -33,16 +33,17 @@ import {
   tableFormatNearZero,
   tableFormatRawCo2e,
 } from '../../../utils/helpers/transformData'
-import { RecommendationRow } from '../../../Types'
+import { Co2eUnit, RecommendationRow } from '../../../Types'
 import RecommendationsSidePanel from '../RecommendationsSidePanel'
+import { co2eUnitAbbreviation } from '../../../utils/helpers'
 
 type RecommendationsTableProps = {
   emissionsData: ServiceData[]
   recommendations: RecommendationResult[]
-  useKilograms: boolean
+  co2eUnit: Co2eUnit
 }
 
-const getColumns = (useKilograms: boolean): GridColDef[] => [
+const getColumns = (co2eUnit: Co2eUnit): GridColDef[] => [
   {
     field: 'cloudProvider',
     headerName: 'Cloud Provider',
@@ -77,12 +78,10 @@ const getColumns = (useKilograms: boolean): GridColDef[] => [
   },
   {
     field: 'co2eSavings',
-    headerName: useKilograms
-      ? 'Potential Carbon Savings (kg)'
-      : 'Potential Carbon Savings (t)',
+    headerName: `Potential Carbon Savings (${co2eUnitAbbreviation[co2eUnit]})`,
     renderCell: (params: GridCellParams) => {
       if (typeof params.value === 'number') {
-        return tableFormatRawCo2e(useKilograms, params.value)
+        return tableFormatRawCo2e(co2eUnit, params.value)
       } else {
         return '-'
       }
@@ -94,7 +93,7 @@ const getColumns = (useKilograms: boolean): GridColDef[] => [
 const RecommendationsTable: FunctionComponent<RecommendationsTableProps> = ({
   emissionsData,
   recommendations,
-  useKilograms,
+  co2eUnit,
 }): ReactElement => {
   const [searchBarValue, setSearchBarValue] = useState('')
   const [rows, setRows] = useState([])
@@ -120,7 +119,7 @@ const RecommendationsTable: FunctionComponent<RecommendationsTableProps> = ({
           const recommendationRow = {
             ...recommendation,
             id: index,
-            useKilograms,
+            co2eUnit: co2eUnit,
             co2eSavings: recommendation.co2eSavings,
           }
           // Replace any undefined values and round numbers to thousandth decimal
@@ -163,7 +162,7 @@ const RecommendationsTable: FunctionComponent<RecommendationsTableProps> = ({
           if (!fieldsToNotFilter.includes(field)) {
             let value = row[field]
             if (field === 'co2eSavings') {
-              value = tableFormatRawCo2e(useKilograms, value)
+              value = tableFormatRawCo2e(co2eUnit, value)
             } else if (field === 'costSavings') {
               value = tableFormatNearZero(value)
             }
@@ -177,7 +176,7 @@ const RecommendationsTable: FunctionComponent<RecommendationsTableProps> = ({
 
   useEffect(() => {
     requestSearch(searchBarValue)
-  }, [useKilograms])
+  }, [co2eUnit])
 
   useEffect(() => {
     requestSearch(searchBarValue)
@@ -219,7 +218,7 @@ const RecommendationsTable: FunctionComponent<RecommendationsTableProps> = ({
           <Forecast
             emissionsData={emissionsData}
             recommendations={recommendations}
-            useKilograms={useKilograms}
+            co2eUnit={co2eUnit}
           />
           <div className={classes.recommendationsContainer}>
             <Typography className={classes.title}>Recommendations</Typography>
@@ -241,7 +240,7 @@ const RecommendationsTable: FunctionComponent<RecommendationsTableProps> = ({
               <DataGrid
                 autoHeight
                 rows={rows}
-                columns={getColumns(useKilograms)}
+                columns={getColumns(co2eUnit)}
                 columnBuffer={6}
                 hideFooterSelectedRowCount={true}
                 classes={{

--- a/packages/client/src/utils/helpers/index.ts
+++ b/packages/client/src/utils/helpers/index.ts
@@ -12,3 +12,9 @@ export {
   useFilterDataFromEstimates,
   getMaxOfDataSeries,
 } from './transformData'
+
+export {
+  co2eUnitMultiplier,
+  co2eUnitLabel,
+  co2eUnitAbbreviation,
+} from './units'

--- a/packages/client/src/utils/helpers/transformData.test.ts
+++ b/packages/client/src/utils/helpers/transformData.test.ts
@@ -27,7 +27,7 @@ import {
   mockEmissionsAndRecommendations,
   mockEmissionsAndRecommendationsWithUnknowns,
 } from '../data/mockData'
-import { UnknownTypes } from '../../Types'
+import { Co2eUnit, UnknownTypes } from '../../Types'
 import each from 'jest-each'
 
 const testAccountA = 'test-a'
@@ -411,21 +411,19 @@ describe('tableFormatNearZero', () => {
 
 describe('tableFormatRawCo2e', () => {
   const a = [
-    [0, false, '0'],
-    [0, true, '0'],
-    [0.0001, false, '< 0.001'],
-    [0.0001, true, '0.1'],
-    [0.00099, false, '0.001'],
-    [0.00099, true, '0.99'],
-    [1, false, '1'],
-    [1, true, '1000'],
+    [0, Co2eUnit.MetricTonnes, '0'],
+    [0, Co2eUnit.Kilograms, '0'],
+    [0.0001, Co2eUnit.MetricTonnes, '< 0.001'],
+    [0.0001, Co2eUnit.Kilograms, '0.1'],
+    [0.00099, Co2eUnit.MetricTonnes, '0.001'],
+    [0.00099, Co2eUnit.Kilograms, '0.99'],
+    [1, Co2eUnit.MetricTonnes, '1'],
+    [1, Co2eUnit.Kilograms, '1000'],
   ]
   each(a).it(
     ' formats Co2e properly',
-    (numericInput: number, useKilograms: boolean, expectedOutput: string) => {
-      expect(tableFormatRawCo2e(useKilograms, numericInput)).toEqual(
-        expectedOutput,
-      )
+    (numericInput: number, co2eUnit: Co2eUnit, expectedOutput: string) => {
+      expect(tableFormatRawCo2e(co2eUnit, numericInput)).toEqual(expectedOutput)
     },
   )
 })

--- a/packages/client/src/utils/helpers/transformData.ts
+++ b/packages/client/src/utils/helpers/transformData.ts
@@ -10,13 +10,15 @@ import {
   ServiceData,
 } from '@cloud-carbon-footprint/common'
 import {
-  cloudEstPerDay,
   ChartDataTypes,
-  FilterResultResponse,
+  cloudEstPerDay,
+  Co2eUnit,
   DropdownOption,
-  UnknownTypes,
   EmissionsAndRecommendationResults,
+  FilterResultResponse,
+  UnknownTypes,
 } from '../../Types'
+import { co2eUnitMultiplier } from './units'
 
 const sumServiceTotals = (
   data: EstimationResult[],
@@ -282,17 +284,14 @@ function tableFormatNearZero(rawValue: number): string {
 }
 
 /**
- * Formats the raw co2e value, optionally multiplying by 1000 if useKilograms
- * is true.
+ * Formats the raw co2e value, converting to the specified unit as required
  *
- * @param useKilograms If true, multiplies the value by 1000
- * @param rawValue     Raw numeric co2e value
+ * @param unit The target unit
+ * @param rawValue Raw numeric co2e value in metric tonnes
  */
-function tableFormatRawCo2e(useKilograms: boolean, rawValue: number): string {
-  if (useKilograms) {
-    rawValue *= 1000
-  }
-  return tableFormatNearZero(rawValue)
+function tableFormatRawCo2e(unit: Co2eUnit, rawValue: number): string {
+  const multiplier = co2eUnitMultiplier[unit]
+  return tableFormatNearZero(rawValue * multiplier)
 }
 
 export {

--- a/packages/client/src/utils/helpers/units.test.ts
+++ b/packages/client/src/utils/helpers/units.test.ts
@@ -1,0 +1,31 @@
+import { Co2eUnit } from 'src/Types'
+import each from 'jest-each'
+import {
+  co2eUnitAbbreviation,
+  co2eUnitLabel,
+  co2eUnitMultiplier,
+} from './units'
+
+describe('co2eUnitMultiplier', () => {
+  const units = Object.values(Co2eUnit)
+  each(units).it('contains a multiplier for unit %p', (unit: Co2eUnit) => {
+    const multiplier = co2eUnitMultiplier[unit]
+    expect(multiplier).toBeDefined()
+  })
+})
+
+describe('co2eUnitLabel', () => {
+  const units = Object.values(Co2eUnit)
+  each(units).it('contains a label for unit %p', (unit: Co2eUnit) => {
+    const label = co2eUnitLabel[unit]
+    expect(label).toBeDefined()
+  })
+})
+
+describe('co2eUnitAbbreviation', () => {
+  const units = Object.values(Co2eUnit)
+  each(units).it('contains an abbreviation for unit %p', (unit: Co2eUnit) => {
+    const abbreviation = co2eUnitAbbreviation[unit]
+    expect(abbreviation).toBeDefined()
+  })
+})

--- a/packages/client/src/utils/helpers/units.ts
+++ b/packages/client/src/utils/helpers/units.ts
@@ -1,0 +1,16 @@
+import { Co2eUnit } from '../../Types'
+
+export const co2eUnitMultiplier: Record<Co2eUnit, number> = {
+  [Co2eUnit.Kilograms]: 1000,
+  [Co2eUnit.MetricTonnes]: 1,
+}
+
+export const co2eUnitLabel: Record<Co2eUnit, string> = {
+  [Co2eUnit.Kilograms]: 'Kilograms',
+  [Co2eUnit.MetricTonnes]: 'Metric Tons',
+}
+
+export const co2eUnitAbbreviation: Record<Co2eUnit, string> = {
+  [Co2eUnit.Kilograms]: 'kg',
+  [Co2eUnit.MetricTonnes]: 't',
+}


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

Refactors useKilograms props in the client to use an enum for the Co2e Unit (tons or kg) to reduce ambiguity. Issue #550 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [ ] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] relevant documentation is changed or added

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
