### PR TITLE
Fix typo in Azure Cache for Redis/C0 size

### DIFF
--- a/packages/azure/src/lib/ConsumptionTypes.ts
+++ b/packages/azure/src/lib/ConsumptionTypes.ts
@@ -114,7 +114,7 @@ export const MEMORY_USAGE_TYPES: string[] = [
 export const CACHE_MEMORY_GB: {
   [cacheName: string]: number
 } = {
-  C0: 250,
+  C0: 0.25,
   C1: 1,
   C2: 2.5,
   C3: 6,


### PR DESCRIPTION
## Description of Change

Changed the cache size of `C0` offer for "Azure Cache for Redis", fixes #974 

© 2021 Thoughtworks, Inc.
