### PR TITLE
Add B DTU storage type to Azure list

### DIFF
--- a/packages/azure/src/lib/ConsumptionTypes.ts
+++ b/packages/azure/src/lib/ConsumptionTypes.ts
@@ -107,6 +107,7 @@ export const STORAGE_USAGE_TYPES: string[] = [
   '10 DTUs',
   'S0 DTUs',
   'B DTUs',
+  'B DTU',
   'eDTUs',
   'On Premises Server Protected Instances',
   'Standard Trial Nodes',


### PR DESCRIPTION
## Description of Change

Ref: https://www.cloudcarbonfootprint.org/docs/azure#unsupported-usage-types

Received the following message:

> [ConsumptionManagement] warn: Unexpected usage type for storage service: B DTU

This PR fixes that by adding "B DTU" to packages\azure\src\lib\ConsumptionTypes.ts


## Notes

Quick search seems to imply that both "B DTU" and "B DTUs" are possible, so I have left them both in.

© 2021 Thoughtworks, Inc.
