### PR TITLE
[964] Add azure tags and resource group to estimates

### DIFF
--- a/.changeset/quiet-dots-relax.md
+++ b/.changeset/quiet-dots-relax.md
@@ -1,0 +1,5 @@
+---
+'@cloud-carbon-footprint/azure': minor
+---
+
+Add support for Azure Tags and resource groups

--- a/.changeset/quiet-dots-relax.md
+++ b/.changeset/quiet-dots-relax.md
@@ -1,5 +1,7 @@
 ---
 '@cloud-carbon-footprint/azure': minor
+'@cloud-carbon-footprint/api': minor
+'@cloud-carbon-footprint/common': minor
 ---
 
 Add support for Azure Tags and resource groups

--- a/packages/api/.env.template
+++ b/packages/api/.env.template
@@ -60,6 +60,9 @@ AZURE_TENANT_ID=your-azure-tenant-id
 # Optionally set this to "GCP" if your Azure credentials are stored in Google Secrets Manager.
 AZURE_AUTH_MODE=default
 
+# Azure resource tag names to include if present, include resourceGroup as a tag name if needed:
+AZURE_RESOURCE_TAG_NAMES=["resourceGroup"] # eg. ["resourceGroup","project","customer"]
+
 # Cache
 
 # Optionally set which cache you are using (defaults to local)

--- a/packages/azure/src/__tests__/ConsumptionManagement.test.ts
+++ b/packages/azure/src/__tests__/ConsumptionManagement.test.ts
@@ -111,6 +111,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 5,
             region: 'uksouth',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.002863085156621724,
@@ -122,6 +125,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 10,
             region: 'westeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.0683736557005491,
@@ -133,6 +139,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Azure App Service',
             cost: 10,
             region: 'CentralUS',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -152,6 +161,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Container Instances',
             cost: 12,
             region: 'SouthCentralUS',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.18258479999999996,
@@ -163,6 +175,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Azure Database for MySQL',
             cost: 12,
             region: 'Unknown',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: 'test-subscription-id',
@@ -174,6 +189,9 @@ describe('Azure Consumption Management Service', () => {
             region: 'ukwest',
             serviceName: 'Virtual Machines Licenses',
             usesAverageCPUConstant: false,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: 'test-subscription-id',
@@ -185,6 +203,9 @@ describe('Azure Consumption Management Service', () => {
             region: 'Unknown',
             serviceName: 'VPN Gateway',
             usesAverageCPUConstant: false,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -233,6 +254,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             cost: 10,
             region: 'uksouth',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.011157869359725106,
@@ -244,6 +268,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             cost: 10,
             region: 'westeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.000204768,
@@ -255,6 +282,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Azure Database for MySQL',
             cost: 5,
             region: 'westeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.00034127999999999996,
@@ -266,6 +296,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Container Registry',
             cost: 5,
             region: 'westeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.018929664000000002,
@@ -277,6 +310,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'HDInsight',
             cost: 5,
             region: 'uksouth',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.068256,
@@ -288,6 +324,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Azure Synapse Analytics',
             cost: 5,
             region: 'uksouth',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.0010238399999999998,
@@ -299,6 +338,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             cost: 5,
             region: 'centralindia',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.003276288,
@@ -358,6 +400,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             cost: 5,
             region: 'uksouth',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 11.850000000000001,
@@ -369,6 +414,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Bandwidth',
             cost: 5,
             region: 'uksouth',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -417,6 +465,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             usesAverageCPUConstant: true,
             kilowattHours: 0.18258564019771067,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: subscriptionId,
@@ -428,6 +479,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Redis Cache',
             usesAverageCPUConstant: false,
             kilowattHours: 0.04459392,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -447,6 +501,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Functions',
             usesAverageCPUConstant: false,
             kilowattHours: 0.0000000143710875,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: subscriptionId,
@@ -458,6 +515,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Container Instances',
             usesAverageCPUConstant: false,
             kilowattHours: 0.0067122042757308,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -506,6 +566,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             usesAverageCPUConstant: false,
             kilowattHours: 0.000000271727136,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: subscriptionId,
@@ -517,6 +580,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             usesAverageCPUConstant: false,
             kilowattHours: 0.0000012510300960000003,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: subscriptionId,
@@ -528,6 +594,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             usesAverageCPUConstant: false,
             kilowattHours: 3.07152e-9,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: subscriptionId,
@@ -539,6 +608,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             usesAverageCPUConstant: false,
             kilowattHours: 0.000005629481856,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -558,6 +630,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             usesAverageCPUConstant: false,
             kilowattHours: 0.013105152,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: subscriptionId,
@@ -569,6 +644,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             usesAverageCPUConstant: false,
             kilowattHours: 0.0017746560000000003,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -617,6 +695,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Azure Database for MySQL',
             usesAverageCPUConstant: false,
             kilowattHours: 0.00000137612903276448,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: subscriptionId,
@@ -628,6 +709,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'SQL Database',
             usesAverageCPUConstant: true,
             kilowattHours: 0.015215399999999999,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -647,6 +731,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Azure Database for MySQL',
             usesAverageCPUConstant: true,
             kilowattHours: 0.18258479999999996,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: subscriptionId,
@@ -658,6 +745,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Azure Cosmos DB',
             usesAverageCPUConstant: false,
             kilowattHours: 0.00000293605970619456,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: subscriptionId,
@@ -669,6 +759,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'SQL Database',
             usesAverageCPUConstant: false,
             kilowattHours: 7.155870966717116e-7,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -744,6 +837,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 5,
             region: 'northeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0,
@@ -755,6 +851,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'API Management',
             cost: 1.579140496,
             region: 'northeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -774,6 +873,9 @@ describe('Azure Consumption Management Service', () => {
             region: 'northeurope',
             serviceName: 'Azure Cosmos DB',
             usesAverageCPUConstant: false,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0,
@@ -785,6 +887,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Advanced Data Security',
             cost: 0.4835702479,
             region: 'northeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -804,6 +909,9 @@ describe('Azure Consumption Management Service', () => {
             region: 'northeurope',
             serviceName: 'Storage',
             usesAverageCPUConstant: false,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0,
@@ -815,6 +923,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Load Balancer',
             cost: 0.006280996057,
             region: 'northeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -834,6 +945,9 @@ describe('Azure Consumption Management Service', () => {
             region: 'northeurope',
             serviceName: 'Container Instances',
             usesAverageCPUConstant: false,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0,
@@ -845,6 +959,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Azure Databricks',
             cost: 18,
             region: 'northeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -864,6 +981,9 @@ describe('Azure Consumption Management Service', () => {
             region: 'All Regions',
             serviceName: 'Azure DNS',
             usesAverageCPUConstant: false,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -913,6 +1033,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 10,
             region: 'northeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.013126433307939065,
@@ -924,6 +1047,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 15,
             region: 'westeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 0.2614738305048199,
@@ -935,6 +1061,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 5,
             region: 'uksouth',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             accountId: 'test-subscription-id',
@@ -946,6 +1075,9 @@ describe('Azure Consumption Management Service', () => {
             region: 'EastUS',
             serviceName: 'Virtual Machines',
             usesAverageCPUConstant: true,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -994,6 +1126,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 10,
             region: 'northeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -1013,6 +1148,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 10,
             region: 'EastUS',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 2.774591597330377,
@@ -1024,6 +1162,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 10,
             region: 'westeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -1112,6 +1253,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             cost: 5,
             region: 'uksouth',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
           {
             kilowattHours: 11.850000000000001,
@@ -1123,6 +1267,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Bandwidth',
             cost: 5,
             region: 'uksouth',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -1175,6 +1322,9 @@ describe('Azure Consumption Management Service', () => {
               serviceName: 'Virtual Machines',
               cost: 5,
               region: 'uksouth',
+              tags: {
+                resourceGroup: 'test-resource-group',
+              },
             },
             {
               kilowattHours: 0.002863085156621724,
@@ -1186,6 +1336,9 @@ describe('Azure Consumption Management Service', () => {
               serviceName: 'Virtual Machines',
               cost: 10,
               region: 'westeurope',
+              tags: {
+                resourceGroup: 'test-resource-group',
+              },
             },
             {
               kilowattHours: 0.0683736557005491,
@@ -1197,6 +1350,9 @@ describe('Azure Consumption Management Service', () => {
               serviceName: 'Azure App Service',
               cost: 10,
               region: 'CentralUS',
+              tags: {
+                resourceGroup: 'test-resource-group',
+              },
             },
             {
               kilowattHours: 0.025359,
@@ -1208,6 +1364,9 @@ describe('Azure Consumption Management Service', () => {
               serviceName: 'Container Instances',
               cost: 12,
               region: 'SouthCentralUS',
+              tags: {
+                resourceGroup: 'test-resource-group',
+              },
             },
             {
               kilowattHours: 0.18258479999999996,
@@ -1219,6 +1378,9 @@ describe('Azure Consumption Management Service', () => {
               serviceName: 'Azure Database for MySQL',
               cost: 12,
               region: 'Unknown',
+              tags: {
+                resourceGroup: 'test-resource-group',
+              },
             },
             {
               accountId: 'test-subscription-id',
@@ -1230,6 +1392,9 @@ describe('Azure Consumption Management Service', () => {
               region: 'ukwest',
               serviceName: 'Virtual Machines Licenses',
               usesAverageCPUConstant: false,
+              tags: {
+                resourceGroup: 'test-resource-group',
+              },
             },
             {
               accountId: 'test-subscription-id',
@@ -1241,6 +1406,9 @@ describe('Azure Consumption Management Service', () => {
               region: 'Unknown',
               serviceName: 'VPN Gateway',
               usesAverageCPUConstant: false,
+              tags: {
+                resourceGroup: 'test-resource-group',
+              },
             },
           ],
           groupBy: GroupBy.week,
@@ -1290,6 +1458,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Virtual Machines',
             cost: 15,
             region: 'westeurope',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,
@@ -1331,7 +1502,7 @@ describe('Azure Consumption Management Service', () => {
   it('Throws an error when iteration on a usageRow fails', async () => {
     const errorMessage = 'Something went wrong!'
     const _headersMap = new Map([
-      ["'x-ms-ratelimit-remaining-microsoft.consumption-tenant-requests':", 1],
+      ['\'x-ms-ratelimit-remaining-microsoft.consumption-tenant-requests\':', 1],
     ])
     const testError = {
       message: errorMessage,

--- a/packages/azure/src/__tests__/ConsumptionManagement.test.ts
+++ b/packages/azure/src/__tests__/ConsumptionManagement.test.ts
@@ -9,6 +9,7 @@ import {
   GroupBy,
   LookupTableInput,
   LookupTableOutput,
+  setConfig,
 } from '@cloud-carbon-footprint/common'
 import {
   ComputeEstimator,
@@ -71,6 +72,12 @@ describe('Azure Consumption Management Service', () => {
     AZURE_CLOUD_CONSTANTS.KILOWATT_HOURS_BY_SERVICE_AND_USAGE_UNIT = {
       total: {},
     }
+
+    setConfig({
+      AZURE: {
+        RESOURCE_TAG_NAMES: ['resourceGroup', 'custom', 'created-by', 'other'],
+      },
+    })
   })
 
   it('Returns estimates for Compute', async () => {

--- a/packages/azure/src/__tests__/ConsumptionManagement.test.ts
+++ b/packages/azure/src/__tests__/ConsumptionManagement.test.ts
@@ -359,6 +359,9 @@ describe('Azure Consumption Management Service', () => {
             serviceName: 'Storage',
             cost: 1,
             region: 'Unknown',
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
           },
         ],
         groupBy: grouping,

--- a/packages/azure/src/__tests__/ConsumptionManagement.test.ts
+++ b/packages/azure/src/__tests__/ConsumptionManagement.test.ts
@@ -1127,7 +1127,9 @@ describe('Azure Consumption Management Service', () => {
             cost: 10,
             region: 'northeurope',
             tags: {
-              resourceGroup: 'test-resource-group',
+              custom: 'custom-tag-value',
+              other: 'other-custom-tag-value',
+              resourceGroup: 'first-resource-group',
             },
           },
         ],
@@ -1149,7 +1151,9 @@ describe('Azure Consumption Management Service', () => {
             cost: 10,
             region: 'EastUS',
             tags: {
-              resourceGroup: 'test-resource-group',
+              custom: 'custom-tag-value',
+              'created-by': 'created-by-tag-value',
+              resourceGroup: 'second-resource-group',
             },
           },
           {
@@ -1163,7 +1167,7 @@ describe('Azure Consumption Management Service', () => {
             cost: 10,
             region: 'westeurope',
             tags: {
-              resourceGroup: 'test-resource-group',
+              resourceGroup: 'third-resource-group',
             },
           },
         ],
@@ -1502,7 +1506,7 @@ describe('Azure Consumption Management Service', () => {
   it('Throws an error when iteration on a usageRow fails', async () => {
     const errorMessage = 'Something went wrong!'
     const _headersMap = new Map([
-      ['\'x-ms-ratelimit-remaining-microsoft.consumption-tenant-requests\':', 1],
+      ["'x-ms-ratelimit-remaining-microsoft.consumption-tenant-requests':", 1],
     ])
     const testError = {
       message: errorMessage,

--- a/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
+++ b/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
@@ -28,7 +28,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -49,7 +49,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -70,7 +70,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -91,7 +91,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -112,7 +112,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -133,7 +133,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -154,7 +154,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -178,7 +178,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -199,7 +199,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -220,7 +220,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -241,7 +241,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -262,7 +262,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -283,7 +283,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -304,7 +304,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -325,7 +325,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -346,7 +346,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -390,7 +390,7 @@ export const mockConsumptionManagementResponseThree: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -411,7 +411,7 @@ export const mockConsumptionManagementResponseThree: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -432,7 +432,7 @@ export const mockConsumptionManagementResponseThree: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -456,7 +456,7 @@ export const mockConsumptionManagementResponseFour: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -477,7 +477,7 @@ export const mockConsumptionManagementResponseFour: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -498,7 +498,7 @@ export const mockConsumptionManagementResponseFour: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -519,7 +519,7 @@ export const mockConsumptionManagementResponseFour: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -542,7 +542,7 @@ export const mockConsumptionManagementResponseFive: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -563,7 +563,7 @@ export const mockConsumptionManagementResponseFive: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -584,7 +584,7 @@ export const mockConsumptionManagementResponseFive: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -605,7 +605,7 @@ export const mockConsumptionManagementResponseFive: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -629,7 +629,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -650,7 +650,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -671,7 +671,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -692,7 +692,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -713,7 +713,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-04'),
@@ -734,7 +734,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-04'),
@@ -758,7 +758,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -779,7 +779,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-04'),
@@ -800,7 +800,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-04'),
@@ -821,7 +821,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-04'),
@@ -842,7 +842,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -866,7 +866,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -887,7 +887,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -908,7 +908,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -929,7 +929,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-03'),
@@ -950,7 +950,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-04'),
@@ -971,7 +971,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-04'),
@@ -992,7 +992,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-05'),
@@ -1013,7 +1013,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-05'),
@@ -1034,7 +1034,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-06'),
@@ -1058,7 +1058,7 @@ export const mockConsumptionManagementResponseNine: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -1079,7 +1079,7 @@ export const mockConsumptionManagementResponseNine: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -1100,7 +1100,7 @@ export const mockConsumptionManagementResponseNine: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -1121,7 +1121,7 @@ export const mockConsumptionManagementResponseNine: UsageDetailResult[] = [
     kind: 'modern',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'modern',
       date: new Date('2020-11-02'),
@@ -1144,7 +1144,7 @@ export const mockConsumptionManagementResponseTen: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-01'),
@@ -1165,7 +1165,7 @@ export const mockConsumptionManagementResponseTen: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-07'),
@@ -1186,7 +1186,7 @@ export const mockConsumptionManagementResponseTen: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-08'),
@@ -1210,7 +1210,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -1231,7 +1231,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
     kind: 'modern',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'modern',
       date: new Date('2020-11-03'),
@@ -1251,7 +1251,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
     kind: 'modern',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'modern',
       date: new Date('2020-11-03'),

--- a/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
+++ b/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
@@ -41,6 +41,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -61,6 +62,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'westeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -81,6 +83,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'CentralUS',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -101,6 +104,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'SouthCentralUS',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -121,6 +125,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'Unknown',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -141,6 +146,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'ukwest',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -161,6 +167,7 @@ export const mockConsumptionManagementResponseOne: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'Unknown',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]
@@ -184,6 +191,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -204,6 +212,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -224,6 +233,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'westeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -244,6 +254,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'westeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -264,6 +275,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'westeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -284,6 +296,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'westeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -304,6 +317,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -324,6 +338,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -344,6 +359,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'centralindia',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -387,6 +403,7 @@ export const mockConsumptionManagementResponseThree: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -407,6 +424,7 @@ export const mockConsumptionManagementResponseThree: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -427,6 +445,7 @@ export const mockConsumptionManagementResponseThree: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]
@@ -450,6 +469,7 @@ export const mockConsumptionManagementResponseFour: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'Unassigned',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -470,6 +490,7 @@ export const mockConsumptionManagementResponseFour: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -490,6 +511,7 @@ export const mockConsumptionManagementResponseFour: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -510,6 +532,7 @@ export const mockConsumptionManagementResponseFour: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]
@@ -532,6 +555,7 @@ export const mockConsumptionManagementResponseFive: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -552,6 +576,7 @@ export const mockConsumptionManagementResponseFive: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'apsoutheast',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -572,6 +597,7 @@ export const mockConsumptionManagementResponseFive: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'EastUS2',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -592,6 +618,7 @@ export const mockConsumptionManagementResponseFive: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'ukwest',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]
@@ -615,6 +642,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'WestUS',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -635,6 +663,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'SouthCentralUS',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -655,6 +684,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -675,6 +705,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uswest2',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -695,6 +726,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -715,6 +747,7 @@ export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'westindia',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]
@@ -738,6 +771,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -758,6 +792,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -778,6 +813,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'CentralUS',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -798,6 +834,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -818,6 +855,7 @@ export const mockConsumptionManagementResponseSeven: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]
@@ -841,6 +879,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -861,6 +900,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -881,6 +921,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -901,6 +942,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -921,6 +963,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -941,6 +984,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -961,6 +1005,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -981,6 +1026,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -1001,6 +1047,7 @@ export const mockConsumptionManagementResponseEight: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'All Regions',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]
@@ -1024,6 +1071,7 @@ export const mockConsumptionManagementResponseNine: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -1044,6 +1092,7 @@ export const mockConsumptionManagementResponseNine: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'westeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -1064,6 +1113,7 @@ export const mockConsumptionManagementResponseNine: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -1083,6 +1133,7 @@ export const mockConsumptionManagementResponseNine: UsageDetailResult[] = [
       subscriptionGuid: 'test-subscription-id',
       subscriptionName: 'test-subscription',
       resourceLocation: 'EASTUS',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]
@@ -1106,6 +1157,7 @@ export const mockConsumptionManagementResponseTen: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -1126,6 +1178,7 @@ export const mockConsumptionManagementResponseTen: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'westeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -1146,6 +1199,7 @@ export const mockConsumptionManagementResponseTen: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'uksouth',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]
@@ -1169,6 +1223,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -1188,6 +1243,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
       subscriptionGuid: 'test-subscription-id',
       subscriptionName: 'test-subscription',
       resourceLocation: 'EASTUS',
+      resourceGroup: 'test-resource-group',
     },
   },
   {
@@ -1207,6 +1263,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
       subscriptionGuid: 'test-subscription-id',
       subscriptionName: 'test-subscription',
       resourceLocation: 'WESTEUROPE',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]

--- a/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
+++ b/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
@@ -1238,6 +1238,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
     tags: {
       custom: 'custom-tag-value',
       'created-by': 'created-by-tag-value',
+      ignored: 'this-tag-should-not-be-visible',
     },
     properties: {
       kind: 'modern',

--- a/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
+++ b/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
@@ -368,7 +368,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: '',
+    tags: {},
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -381,6 +381,7 @@ export const mockConsumptionManagementResponseTwo: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'Unknown',
+      resourceGroup: 'test-resource-group',
     },
   },
 ]

--- a/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
+++ b/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
@@ -6,6 +6,7 @@ import { UsageDetailResult } from '../../lib/ConsumptionTypes'
 
 interface IterableMockResponse {
   next(): Promise<IteratorResult<UsageDetailResult>>
+
   [Symbol.asyncIterator](): IterableMockResponse
 }
 
@@ -1210,7 +1211,10 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
     kind: 'legacy',
     name: 'name',
     type: 'type',
-    tags: {},
+    tags: {
+      custom: 'custom-tag-value',
+      other: 'other-custom-tag-value',
+    },
     properties: {
       kind: 'legacy',
       date: new Date('2020-11-02'),
@@ -1223,7 +1227,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
       },
       subscriptionName: 'test-subscription',
       resourceLocation: 'northeurope',
-      resourceGroup: 'test-resource-group',
+      resourceGroup: 'first-resource-group',
     },
   },
   {
@@ -1231,7 +1235,10 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
     kind: 'modern',
     name: 'name',
     type: 'type',
-    tags: {},
+    tags: {
+      custom: 'custom-tag-value',
+      'created-by': 'created-by-tag-value',
+    },
     properties: {
       kind: 'modern',
       date: new Date('2020-11-03'),
@@ -1243,7 +1250,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
       subscriptionGuid: 'test-subscription-id',
       subscriptionName: 'test-subscription',
       resourceLocation: 'EASTUS',
-      resourceGroup: 'test-resource-group',
+      resourceGroup: 'second-resource-group',
     },
   },
   {
@@ -1263,7 +1270,7 @@ export const mockConsumptionManagementResponseEleven: UsageDetailResult[] = [
       subscriptionGuid: 'test-subscription-id',
       subscriptionName: 'test-subscription',
       resourceLocation: 'WESTEUROPE',
-      resourceGroup: 'test-resource-group',
+      resourceGroup: 'third-resource-group',
     },
   },
 ]

--- a/packages/azure/src/lib/ConsumptionDetailRow.ts
+++ b/packages/azure/src/lib/ConsumptionDetailRow.ts
@@ -24,6 +24,10 @@ export default class ConsumptionDetailRow extends BillingDataRow {
     this.vCpuHours = this.usageAmount * this.getVCpus()
     this.gpuHours = this.usageAmount * this.getGpus()
     this.region = this.getRegionFromResourceLocation()
+    this.tags = {
+      ...usageDetail.tags,
+      resourceGroup: usageDetail.properties.resourceGroup,
+    }
   }
 
   public getVCpus(): number {

--- a/packages/azure/src/lib/ConsumptionManagement.ts
+++ b/packages/azure/src/lib/ConsumptionManagement.ts
@@ -166,7 +166,7 @@ export default class ConsumptionManagementService {
         id: '',
         name: '',
         type: '',
-        tags: '',
+        tags: {},
         kind: 'legacy' as const,
         properties: {
           kind: 'legacy' as const,

--- a/packages/azure/src/lib/ConsumptionTypes.ts
+++ b/packages/azure/src/lib/ConsumptionTypes.ts
@@ -23,11 +23,15 @@ export type UsageRowPageErrorResponse = {
   message: string
 }
 
+type AzureTags = {
+  [tagKey: string]: string
+}
+
 export type UsageDetailResult = {
   id: string
   name: string
   type: string
-  tags: any
+  tags: AzureTags
   kind: string
   properties: LegacyUsageDetail | ModernUsageDetail
 }

--- a/packages/common/src/Config.ts
+++ b/packages/common/src/Config.ts
@@ -55,6 +55,7 @@ export interface CCFConfig {
       clientSecret?: string
       tenantId?: string
     }
+    RESOURCE_TAG_NAMES?: string[]
   }
   LOGGING_MODE?: string
   CACHE_MODE?: string
@@ -102,6 +103,12 @@ const getAWSAccounts = () => {
 const getAWSResourceTagNames = () => {
   return process.env.AWS_RESOURCE_TAG_NAMES
     ? process.env.AWS_RESOURCE_TAG_NAMES
+    : '[]'
+}
+
+const getAzureResourceTagNames = () => {
+  return process.env.AZURE_RESOURCE_TAG_NAMES
+    ? process.env.AZURE_RESOURCE_TAG_NAMES
     : '[]'
 }
 
@@ -235,6 +242,7 @@ const getConfig = (): CCFConfig => ({
       clientSecret: getEnvVar('AZURE_CLIENT_SECRET') || '',
       tenantId: getEnvVar('AZURE_TENANT_ID') || '',
     },
+    RESOURCE_TAG_NAMES: JSON.parse(getAzureResourceTagNames()),
   },
   LOGGING_MODE: process.env.LOGGING_MODE || '',
   CACHE_MODE: getEnvVar('CACHE_MODE') || '',


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

fixes #964 

This PR adds support for azure tags and resourceGroups via the existing `tags` field in the estimations as described in #964 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] tests are changed or added
- [ ] yarn test passes
      (There are problems with some tests from the azure recommendations, but I did not change any values there...)
- [X] yarn lint has been run
- [X] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [X] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] relevant documentation is changed or added
      (Was out of scope)

## Notes

No points in the `Out of scope` section of the issue have been resolved yet.

© 2021 Thoughtworks, Inc.
