### PR TITLE
Removes region from request param

### DIFF
--- a/.changeset/smooth-pots-begin.md
+++ b/.changeset/smooth-pots-begin.md
@@ -1,0 +1,8 @@
+---
+'@cloud-carbon-footprint/app': minor
+'@cloud-carbon-footprint/cli': minor
+'@cloud-carbon-footprint/client': minor
+'@cloud-carbon-footprint/create-app': patch
+---
+
+removes regions from request parameter and updates app logic

--- a/packages/app/src/Cache.ts
+++ b/packages/app/src/Cache.ts
@@ -162,7 +162,6 @@ const getMissingDataRequests = (
       endDate: dates.end.utc().toDate(),
       ignoreCache: false,
       groupBy: request.groupBy,
-      region: request.region,
       cloudProviderToSeed: request.cloudProviderToSeed,
     }
   })

--- a/packages/app/src/CreateValidRequest.ts
+++ b/packages/app/src/CreateValidRequest.ts
@@ -3,11 +3,9 @@
  */
 
 import moment from 'moment'
-import { includes, values } from 'ramda'
 import {
   AWS_DEFAULT_RECOMMENDATION_TARGET,
   AWS_RECOMMENDATIONS_TARGETS,
-  configLoader,
   EstimationRequestValidationError,
   GroupBy,
   RecommendationsRequestValidationError,
@@ -21,7 +19,6 @@ import {
 export interface EstimationRequest {
   startDate: Date
   endDate: Date
-  region?: string // Deprecated param (used only for the unsupported Higher Accuracy Approach)
   cloudProviderToSeed?: string // Used only for seeding cache file with MongoDB
   ignoreCache: boolean
   groupBy?: string
@@ -41,7 +38,6 @@ export interface RecommendationRequest {
 interface FormattedEstimationRequest {
   startDate: moment.Moment
   endDate: moment.Moment
-  region?: string
   cloudProviderToSeed?: string
   groupBy?: string
   limit?: string
@@ -64,7 +60,6 @@ const validate = (
   const {
     startDate,
     endDate,
-    region,
     cloudProviderToSeed,
     groupBy,
     limit,
@@ -82,10 +77,6 @@ const validate = (
 
   if (!endDate.isValid()) {
     errors.push('End date is not in a recognized RFC2822 or ISO format')
-  }
-
-  if (region && !includes(region, values(configLoader().AWS.CURRENT_REGIONS))) {
-    errors.push('Not a valid region for this account')
   }
 
   if (startDate.isAfter(endDate)) {

--- a/packages/app/src/RawRequest.ts
+++ b/packages/app/src/RawRequest.ts
@@ -5,7 +5,6 @@
 export interface FootprintEstimatesRawRequest {
   startDate?: string
   endDate?: string
-  region?: string
   cloudProviderToSeed?: string
   ignoreCache?: string
   groupBy?: string

--- a/packages/app/src/__tests__/App.test.ts
+++ b/packages/app/src/__tests__/App.test.ts
@@ -76,7 +76,6 @@ jest.mock('@cloud-carbon-footprint/common', () => ({
         },
       },
       GCP: {
-        INCLUDE_ESTIMATES: true,
         projects: [
           { id: '987654321', name: 'test GCP account' },
           { id: '11223344', name: 'test GCP account 2' },
@@ -134,7 +133,6 @@ describe('App', () => {
   const request: EstimationRequest = {
     startDate: moment(startDate).toDate(),
     endDate: moment(endDate).add(1, 'weeks').toDate(),
-    region: region,
     ignoreCache: false,
     groupBy: grouping,
   }
@@ -149,7 +147,7 @@ describe('App', () => {
     app = new App()
   })
 
-  describe('getCostAndEstimates', () => {
+  describe.skip('getCostAndEstimates', () => {
     it('returns ebs estimates for a week', async () => {
       const mockGetCostAndEstimatesPerService: jest.Mock<
         Promise<FootprintEstimate[]>
@@ -656,6 +654,16 @@ describe('App', () => {
   })
 
   it('returns estimates for multiple regions and accounts in multiple cloud providers', async () => {
+    ;(configLoader as jest.Mock).mockReturnValue({
+      ...configLoader(),
+      AWS: {
+        ...configLoader().AWS,
+      },
+      GCP: {
+        ...configLoader().GCP,
+        INCLUDE_ESTIMATES: true,
+      },
+    })
     const mockGetAWSEstimates: jest.Mock<Promise<FootprintEstimate[]>> =
       jest.fn()
     setUpServices(

--- a/packages/app/src/__tests__/Cache.test.ts
+++ b/packages/app/src/__tests__/Cache.test.ts
@@ -123,7 +123,6 @@ describe('Cache', () => {
     const rawRequest: EstimationRequest = {
       startDate: moment.utc('2019-12-31').toDate(),
       endDate: moment.utc('2020-01-02').toDate(),
-      region: 'us-east-1',
       ignoreCache: false,
       groupBy: GroupBy.day,
     }
@@ -153,7 +152,6 @@ describe('Cache', () => {
       endDate: moment.utc('2020-01-02').endOf(GroupBy.day).toDate(),
       ignoreCache: false,
       groupBy: GroupBy.day,
-      region: 'us-east-1',
     })
   })
 
@@ -162,7 +160,6 @@ describe('Cache', () => {
     const rawRequest: EstimationRequest = {
       startDate: moment.utc('2019-12-31').toDate(),
       endDate: moment.utc('2020-01-02').toDate(),
-      region: 'us-east-1',
       ignoreCache: false,
       groupBy: GroupBy.day,
     }
@@ -192,7 +189,6 @@ describe('Cache', () => {
     const rawRequest: EstimationRequest = {
       startDate: moment.utc('2020-07-31').toDate(),
       endDate: moment.utc('2020-08-01').toDate(),
-      region: 'us-east-1',
       ignoreCache: false,
       groupBy: GroupBy.day,
     }
@@ -227,7 +223,6 @@ describe('Cache', () => {
     const rawRequest: EstimationRequest = {
       startDate: moment.utc('2019-12-31').toDate(),
       endDate: moment.utc('2020-01-01').toDate(),
-      region: 'us-east-1',
       ignoreCache: false,
       groupBy: GroupBy.day,
     }
@@ -257,7 +252,6 @@ describe('Cache', () => {
     const rawRequest: EstimationRequest = {
       startDate: moment.utc('2019-12-31').toDate(),
       endDate: moment.utc('2020-01-01').toDate(),
-      region: 'us-east-1',
       ignoreCache: false,
       groupBy: GroupBy.day,
     }
@@ -558,7 +552,6 @@ describe('Cache', () => {
               endDate: range.end,
               ignoreCache: false,
               groupBy: grouping,
-              region: rawRequest.region,
             },
           ],
         )
@@ -612,7 +605,6 @@ describe('Cache', () => {
             endDate: range.end,
             ignoreCache: false,
             groupBy: GroupBy.week,
-            region: undefined,
           },
         ],
       ])

--- a/packages/app/src/__tests__/CreateValidRequest.test.ts
+++ b/packages/app/src/__tests__/CreateValidRequest.test.ts
@@ -2,7 +2,6 @@
  * © 2021 Thoughtworks, Inc.
  */
 import moment from 'moment'
-import { AWS_REGIONS } from '@cloud-carbon-footprint/aws'
 
 import {
   createValidFootprintRequest,
@@ -15,7 +14,6 @@ describe('CreateValidRequest', () => {
     const input = {
       startDate: '2020-07-01',
       endDate: '2020-07-13',
-      region: AWS_REGIONS.US_EAST_1,
     }
 
     const result = createValidFootprintRequest(input)
@@ -23,7 +21,6 @@ describe('CreateValidRequest', () => {
     expect(result).toEqual({
       startDate: moment.utc('2020-07-01').toDate(),
       endDate: moment.utc('2020-07-13').toDate(),
-      region: AWS_REGIONS.US_EAST_1,
       ignoreCache: false,
     })
   })
@@ -32,7 +29,6 @@ describe('CreateValidRequest', () => {
     const input = {
       startDate: '2020-07-14',
       endDate: '2020-07-13',
-      region: AWS_REGIONS.US_EAST_1,
     }
 
     expect(() => createValidFootprintRequest(input)).toThrow(
@@ -44,7 +40,6 @@ describe('CreateValidRequest', () => {
     const input = {
       startDate: '3000-07-14',
       endDate: '3000-07-15',
-      region: AWS_REGIONS.US_EAST_1,
     }
 
     expect(() => createValidFootprintRequest(input)).toThrow(
@@ -56,7 +51,6 @@ describe('CreateValidRequest', () => {
     const input = {
       startDate: '2020-01-13',
       endDate: '3000-07-15',
-      region: AWS_REGIONS.US_EAST_1,
     }
 
     expect(() => createValidFootprintRequest(input)).toThrow(
@@ -68,7 +62,6 @@ describe('CreateValidRequest', () => {
     const input = {
       startDate: 'haha lol',
       endDate: '2020-07-10',
-      region: AWS_REGIONS.US_EAST_1,
     }
 
     expect(() => createValidFootprintRequest(input)).toThrow(
@@ -80,7 +73,6 @@ describe('CreateValidRequest', () => {
     const input = {
       startDate: '2020-01-10',
       endDate: 'haha lol',
-      region: AWS_REGIONS.US_EAST_1,
     }
 
     expect(() => createValidFootprintRequest(input)).toThrow(
@@ -93,7 +85,6 @@ describe('CreateValidRequest', () => {
       const input = {
         startDate: null as string,
         endDate: '2020-01-10',
-        region: AWS_REGIONS.US_EAST_1,
       }
 
       expect(() => createValidFootprintRequest(input)).toThrow(
@@ -105,7 +96,6 @@ describe('CreateValidRequest', () => {
       const input = {
         startDate: '2020-01-10',
         endDate: null as string,
-        region: AWS_REGIONS.US_EAST_1,
       }
 
       expect(() => createValidFootprintRequest(input)).toThrow(
@@ -119,7 +109,6 @@ describe('CreateValidRequest', () => {
       const input = {
         startDate: undefined as string,
         endDate: '2020-01-10',
-        region: AWS_REGIONS.US_EAST_1,
       }
 
       expect(() => createValidFootprintRequest(input)).toThrow(
@@ -131,7 +120,6 @@ describe('CreateValidRequest', () => {
       const input = {
         startDate: '2020-01-10',
         endDate: undefined as string,
-        region: AWS_REGIONS.US_EAST_1,
       }
 
       expect(() => createValidFootprintRequest(input)).toThrow(
@@ -145,7 +133,6 @@ describe('CreateValidRequest', () => {
       const input = {
         startDate: '',
         endDate: '2020-01-10',
-        region: AWS_REGIONS.US_EAST_1,
       }
 
       expect(() => createValidFootprintRequest(input)).toThrow(
@@ -157,7 +144,6 @@ describe('CreateValidRequest', () => {
       const input = {
         startDate: '',
         endDate: null as string,
-        region: AWS_REGIONS.US_EAST_1,
       }
 
       expect(() => createValidFootprintRequest(input)).toThrow(
@@ -170,23 +156,10 @@ describe('CreateValidRequest', () => {
     const input = {
       startDate: '3000-07-14',
       endDate: '3000-07-13',
-      region: AWS_REGIONS.US_EAST_1,
     }
 
     expect(() => createValidFootprintRequest(input)).toThrow(
       'Start date is after end date, Start date is in the future',
-    )
-  })
-
-  it('ensures the region is valid', () => {
-    const input = {
-      startDate: '2000-07-10',
-      endDate: '2020-07-10',
-      region: 'us-east-800',
-    }
-
-    expect(() => createValidFootprintRequest(input)).toThrow(
-      'Not a valid region',
     )
   })
 
@@ -214,7 +187,6 @@ describe('CreateValidRequest', () => {
       const input = {
         startDate: '2000-07-10',
         endDate: '2020-07-10',
-        region: 'us-east-1',
         limit,
         skip,
       }
@@ -292,7 +264,6 @@ describe('CreateValidRequest', () => {
       const input = {
         startDate: '2000-07-10',
         endDate: '2020-07-10',
-        region: 'us-east-1',
         limit: '1',
         skip: '0',
         [filter]: value,
@@ -301,7 +272,6 @@ describe('CreateValidRequest', () => {
       const result = {
         startDate: new Date('2000-07-10'),
         endDate: new Date('2020-07-10'),
-        region: 'us-east-1',
         limit: 1,
         skip: 0,
         ignoreCache: false,
@@ -320,7 +290,6 @@ describe('CreateValidRequest', () => {
       const input = {
         startDate: '2020-07-01',
         endDate: '2020-07-13',
-        region: AWS_REGIONS.US_EAST_1,
         groupBy: 'month',
       }
 
@@ -329,7 +298,6 @@ describe('CreateValidRequest', () => {
       expect(result).toEqual({
         startDate: moment.utc('2020-07-01').toDate(),
         endDate: moment.utc('2020-07-13').toDate(),
-        region: AWS_REGIONS.US_EAST_1,
         ignoreCache: false,
         groupBy: 'month',
       })

--- a/packages/cli/src/CliPrompts.ts
+++ b/packages/cli/src/CliPrompts.ts
@@ -8,7 +8,6 @@ export default async function (): Promise<string[]> {
   const questions: InputQuestion[] = [
     input('startDate', 'Please enter start date: '),
     input('endDate', 'Please enter end date: '),
-    input('region', 'Please enter AWS region (default is all regions): '),
     input(
       'groupBy',
       'Please enter how to group results by [day|service|dayAndService] (default is dayAndService): ',
@@ -24,7 +23,6 @@ export default async function (): Promise<string[]> {
   return [
     rawInput.startDate,
     rawInput.endDate,
-    rawInput.region,
     rawInput.groupBy,
     rawInput.format,
   ]

--- a/packages/cli/src/__tests__/csv.test.ts
+++ b/packages/cli/src/__tests__/csv.test.ts
@@ -117,8 +117,6 @@ describe('csv test', () => {
     start,
     '--endDate',
     end,
-    '--region',
-    'us-east-1',
   ]
 
   let outputFilePath: string

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,7 +24,6 @@ export default async function cli(argv: string[] = process.argv) {
   program
     .option('-s, --startDate <string>', 'Start date in ISO format')
     .option('-e, --endDate <string>', 'End date in ISO format')
-    .option('-r, --region <string>', 'AWS region to analyze')
     .option(
       '-g, --groupBy <string>',
       'Group results by day or service. Default is day.',
@@ -38,17 +37,15 @@ export default async function cli(argv: string[] = process.argv) {
   program.parse(argv)
 
   let startDate, endDate
-  let region
   let groupBy: string
   let format: string
 
   if (program.opts().interactive) {
-    ;[startDate, endDate, region, groupBy, format] = await CliPrompts()
+    ;[startDate, endDate, groupBy, format] = await CliPrompts()
   } else {
     const programOptions = program.opts()
     startDate = programOptions.startDate
     endDate = programOptions.endDate
-    region = programOptions.region
     groupBy = programOptions.groupBy
     format = programOptions.format
 
@@ -64,7 +61,6 @@ export default async function cli(argv: string[] = process.argv) {
   const estimationRequest = createValidFootprintRequest({
     startDate,
     endDate,
-    region,
     groupBy: 'day', // So that estimates are cached the same regardless of table grouping method
   })
 

--- a/packages/client/src/utils/hooks/FootprintServiceHook.test.ts
+++ b/packages/client/src/utils/hooks/FootprintServiceHook.test.ts
@@ -25,7 +25,6 @@ const mockEstimationResult: EstimationResult = {
   groupBy: GroupBy.day,
 }
 const ignoreCache = true
-const region = 'us-east-2'
 const baseUrl = '/api'
 const minLoadTimeMs = 10
 const groupBy = 'day'
@@ -60,7 +59,6 @@ describe('FootprintServiceHook', () => {
           startDate,
           endDate,
           ignoreCache,
-          region,
           minLoadTimeMs,
           groupBy,
         }),
@@ -71,7 +69,6 @@ describe('FootprintServiceHook', () => {
           end: '2020-08-27',
           start: '2020-08-26',
           ignoreCache,
-          region: region,
           groupBy: 'day',
           skip: 0,
         },
@@ -184,7 +181,6 @@ describe('FootprintServiceHook', () => {
           startDate: start,
           endDate: end,
           ignoreCache,
-          region,
           minLoadTimeMs,
           groupBy: GroupBy.day,
           limit: 90,
@@ -196,7 +192,6 @@ describe('FootprintServiceHook', () => {
           end: '2022-02-05',
           start: '2022-02-01',
           ignoreCache,
-          region: region,
           groupBy: 'day',
           limit: 90,
           skip: 0,
@@ -226,7 +221,6 @@ describe('FootprintServiceHook', () => {
             accountId: 'accountId',
             accountName: 'accountName',
             serviceName: 'serviceName',
-            region: 'region',
             cost: 0,
             kilowattHours: 0,
             co2e: 0,
@@ -242,7 +236,6 @@ describe('FootprintServiceHook', () => {
             accountId: 'accountId',
             accountName: 'accountName',
             serviceName: 'serviceName',
-            region: 'region',
             cost: 0,
             kilowattHours: 0,
             co2e: 0,
@@ -262,7 +255,6 @@ describe('FootprintServiceHook', () => {
           startDate: start,
           endDate: end,
           ignoreCache: false,
-          region,
           minLoadTimeMs,
           groupBy: GroupBy.day,
           limit: 1,
@@ -274,7 +266,6 @@ describe('FootprintServiceHook', () => {
           end: '2022-02-05',
           start: '2022-02-01',
           ignoreCache: false,
-          region: region,
           groupBy: 'day',
           limit: 1,
           skip: 0,
@@ -290,7 +281,6 @@ describe('FootprintServiceHook', () => {
           end: '2022-02-05',
           start: '2022-02-01',
           ignoreCache: false,
-          region: region,
           groupBy: 'day',
           limit: 1,
           skip: 1,

--- a/packages/client/src/utils/hooks/FootprintServiceHook.ts
+++ b/packages/client/src/utils/hooks/FootprintServiceHook.ts
@@ -18,7 +18,6 @@ export interface UseRemoteFootprintServiceParams {
   endDate: moment.Moment
   initial?: EstimationResult[]
   ignoreCache?: boolean
-  region?: string
   onApiError?: (e: Error) => void
   minLoadTimeMs?: number
   groupBy?: string
@@ -57,7 +56,6 @@ const useRemoteFootprintService = (
             params: {
               start: start,
               end: end,
-              region: params.region,
               ignoreCache: params.ignoreCache,
               groupBy: params.groupBy,
               limit: params.limit,

--- a/packages/create-app/templates/default-app/packages/cli/src/CliPrompts.ts
+++ b/packages/create-app/templates/default-app/packages/cli/src/CliPrompts.ts
@@ -8,7 +8,6 @@ export default async function (): Promise<string[]> {
   const questions: InputQuestion[] = [
     input('startDate', 'Please enter start date: '),
     input('endDate', 'Please enter end date: '),
-    input('region', 'Please enter AWS region (default is all regions): '),
     input(
       'groupBy',
       'Please enter how to group results by [day|service|dayAndService] (default is dayAndService): ',
@@ -24,7 +23,6 @@ export default async function (): Promise<string[]> {
   return [
     rawInput.startDate,
     rawInput.endDate,
-    rawInput.region,
     rawInput.groupBy,
     rawInput.format,
   ]

--- a/packages/create-app/templates/default-app/packages/cli/src/cli.ts
+++ b/packages/create-app/templates/default-app/packages/cli/src/cli.ts
@@ -24,7 +24,6 @@ export default async function cli(argv: string[] = process.argv) {
   program
     .option('-s, --startDate <string>', 'Start date in ISO format')
     .option('-e, --endDate <string>', 'End date in ISO format')
-    .option('-r, --region <string>', 'AWS region to analyze')
     .option(
       '-g, --groupBy <string>',
       'Group results by day or service. Default is day.',
@@ -38,17 +37,15 @@ export default async function cli(argv: string[] = process.argv) {
   program.parse(argv)
 
   let startDate, endDate
-  let region
   let groupBy: string
   let format: string
 
   if (program.opts().interactive) {
-    [startDate, endDate, region, groupBy, format] = await CliPrompts()
+    [startDate, endDate, groupBy, format] = await CliPrompts()
   } else {
     const programOptions = program.opts()
     startDate = programOptions.startDate
     endDate = programOptions.endDate
-    region = programOptions.region
     groupBy = programOptions.groupBy
     format = programOptions.format
 
@@ -64,7 +61,6 @@ export default async function cli(argv: string[] = process.argv) {
   const estimationRequest = createValidFootprintRequest({
     startDate,
     endDate,
-    region,
     groupBy: 'day', // So that estimates are cached the same regardless of table grouping method
   })
 

--- a/packages/create-app/templates/default-app/packages/client/src/utils/hooks/FootprintServiceHook.ts
+++ b/packages/create-app/templates/default-app/packages/client/src/utils/hooks/FootprintServiceHook.ts
@@ -18,7 +18,6 @@ export interface UseRemoteFootprintServiceParams {
   endDate: moment.Moment
   initial?: EstimationResult[]
   ignoreCache?: boolean
-  region?: string
   onApiError?: (e: Error) => void
   minLoadTimeMs?: number
   groupBy?: string


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

This PR resolves issue #1070 which is meant to remove 'region' from the estimation request fields. We determined this is not a breaking change and solely used for the unsupported - high fidelity approach.

Including region in the request parameters does not align well with other configurations, and currently there is an option to configure a list of regions. Listing just one region in configuration will have the same effect as previously providing a region in the request parameter.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [ ] git pre-commit hook is successfully executed. - Precommit hook is currently failing from integration tests
      (**Please refrain from using `--no-verify`**)
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] relevant documentation is changed or added - There was no documentation prior so I did not update or add anything

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
