### PR TITLE
Add Unsupported Usage Types

### DIFF
--- a/packages/aws/src/lib/CostAndUsageTypes.ts
+++ b/packages/aws/src/lib/CostAndUsageTypes.ts
@@ -46,6 +46,7 @@ export const SSD_USAGE_TYPES: string[] = [
   'ra3.16xlarge', // Redshift SSD
   'Storage.SSD.50', // Fsx
   'Storage.MultiAZ:SSD', // Fsx
+  'RDS:GP3-Storage', // RDS
 ]
 
 export const HDD_USAGE_TYPES: string[] = [
@@ -98,6 +99,10 @@ export const HDD_USAGE_TYPES: string[] = [
   'WarmStorage-ByteHrs-DynamoDB', //AWSBackup
   'MagneticStore-ByteHrs', // EBS Backup
   'ColdStorage-ByteHrs-DynamoDB', //AWSBackup
+  'WarmStorage-ByteHrs-S3', // S3
+  'AMP:MetricStorageByteHrs',
+  'TimedStorage-INT-AIA-ByteHrs', // S3 Glacier
+  'TimedStorage-GIR-ByteHrs', // S3 Glacier
 ]
 
 export const NETWORKING_USAGE_TYPES: string[] = [
@@ -169,6 +174,12 @@ export const UNKNOWN_USAGE_TYPES: string[] = [
   'Kafka.mcu.general',
   'SnapshotArchiveStorage',
   'PaidPrivateCA',
+  'Firehose-VpcDelivery-Hours',
+  'Airflow-MediumEnvironment',
+  'IPAddressManager-IP-Hours',
+  'Gateway:VTL-Storage',
+  'Aurora:ServerlessV2Usage', // RDS Aurora
+
 ]
 
 export const UNSUPPORTED_USAGE_TYPES: string[] = [

--- a/packages/aws/src/lib/CostAndUsageTypes.ts
+++ b/packages/aws/src/lib/CostAndUsageTypes.ts
@@ -179,7 +179,6 @@ export const UNKNOWN_USAGE_TYPES: string[] = [
   'IPAddressManager-IP-Hours',
   'Gateway:VTL-Storage',
   'Aurora:ServerlessV2Usage', // RDS Aurora
-
 ]
 
 export const UNSUPPORTED_USAGE_TYPES: string[] = [


### PR DESCRIPTION
Update list of Unsupported Usage Types

Following the documentation I propose to merge new discovered Unsupported Usage Types

-->

'WarmStorage-ByteHrs-S3', // S3
'AMP:MetricStorageByteHrs',
'TimedStorage-INT-AIA-ByteHrs', // S3 Glacier
'TimedStorage-GIR-ByteHrs', // S3 Glacier
'Firehose-VpcDelivery-Hours',
'Airflow-MediumEnvironment',
'IPAddressManager-IP-Hours',
'Gateway:VTL-Storage',
'Aurora:ServerlessV2Usage', // RDS Aurora
'RDS:GP3-Storage', // RDS