### PR TITLE
[#1084] export some objects from package aws

### DIFF
--- a/packages/aws/src/lib/CostAndUsageReports.ts
+++ b/packages/aws/src/lib/CostAndUsageReports.ts
@@ -209,7 +209,7 @@ export default class CostAndUsageReports {
     return result
   }
 
-  private getFootprintEstimateFromUsageRow(
+  getFootprintEstimateFromUsageRow(
     costAndUsageReportRow: CostAndUsageReportsRow,
     unknownRows: CostAndUsageReportsRow[],
   ): FootprintEstimate | void {

--- a/packages/aws/src/lib/index.ts
+++ b/packages/aws/src/lib/index.ts
@@ -12,6 +12,7 @@ export { default as RDSStorage } from './RDSStorage'
 export { default as Lambda } from './Lambda'
 export { ServiceWrapper } from './ServiceWrapper'
 export { default as CostAndUsageReports } from './CostAndUsageReports'
+export * from './CostAndUsageTypes'
 export { AWS_REGIONS } from './AWSRegions'
 export {
   RightsizingRecommendations,


### PR DESCRIPTION


## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->
fix #1084 
export CostAndUsageTypes and getFootprintEstimateFromUsageRow function
As issue #1084 mentioned, in my usage, I imported some of packages as the 3rd party libraries in my project. It's better to use function "getFootprintEstimateFromUsageRow" of "CostAndUsageReports.ts" directly.
Are you willing to export them?
