### PR TITLE
fix: recommendation amount formatting error, recommendation last 30 days error

### DIFF
--- a/.changeset/fuzzy-bulldogs-sing.md
+++ b/.changeset/fuzzy-bulldogs-sing.md
@@ -1,0 +1,5 @@
+---
+'@cloud-carbon-footprint/client': patch
+---
+
+Improves recommendations forecast accuracy, and fixes cost formatting errors for local currencies

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsPage.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsPage.tsx
@@ -60,7 +60,7 @@ const RecommendationsPage = ({
       <div className={classes.boxContainer}>
         <Grid container spacing={3}>
           <RecommendationsTable
-            emissionsData={recommendations.filteredEmissionsData}
+            emissionsData={slicedFootprint}
             recommendations={recommendations.filteredRecommendationData}
             co2eUnit={co2eUnit}
             forecastDetails={forecastDetails}

--- a/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
+++ b/packages/client/src/pages/RecommendationsPage/RecommendationsTable/RecommendationsTable.test.tsx
@@ -345,7 +345,7 @@ describe('Recommendations Table', () => {
 
     const firstRow = actualRowData[0]
 
-    expect(firstRow[firstRow.length - 1].innerHTML).toBe('2560')
+    expect(firstRow[firstRow.length - 1].innerHTML).toBe('2,560')
 
     const table = within(getByRole('grid'))
 
@@ -395,7 +395,7 @@ describe('Recommendations Table', () => {
       ['us-west-1', true, 1, Co2eUnit.MetricTonnes],
       ['Modify', true, 1, Co2eUnit.MetricTonnes],
       [2.539, true, 1, Co2eUnit.MetricTonnes],
-      [2539, true, 1, Co2eUnit.Kilograms],
+      ['2,539', true, 1, Co2eUnit.Kilograms],
       ['pizza', undefined, 0, Co2eUnit.MetricTonnes],
       [6.2, undefined, 0, Co2eUnit.MetricTonnes],
     ]

--- a/packages/client/src/utils/helpers/transformData.test.ts
+++ b/packages/client/src/utils/helpers/transformData.test.ts
@@ -418,7 +418,7 @@ describe('tableFormatRawCo2e', () => {
     [0.00099, Co2eUnit.MetricTonnes, '0.001'],
     [0.00099, Co2eUnit.Kilograms, '0.99'],
     [1, Co2eUnit.MetricTonnes, '1'],
-    [1, Co2eUnit.Kilograms, '1000'],
+    [1, Co2eUnit.Kilograms, '1,000'],
   ]
   each(a).it(
     ' formats Co2e properly',

--- a/packages/client/src/utils/helpers/transformData.ts
+++ b/packages/client/src/utils/helpers/transformData.ts
@@ -277,7 +277,7 @@ const useFilterDataFromRecommendations = (
 function tableFormatNearZero(rawValue: number): string {
   const formattedValue = rawValue
     .toLocaleString(undefined, {
-      maximumFractionDigits: 2,
+      maximumFractionDigits: 3,
     })
   return formattedValue === '0' && rawValue > 0 ? '< 0.001' : formattedValue
 }

--- a/packages/client/src/utils/helpers/transformData.ts
+++ b/packages/client/src/utils/helpers/transformData.ts
@@ -275,10 +275,9 @@ const useFilterDataFromRecommendations = (
  * @param rawValue Raw numeric value to format
  */
 function tableFormatNearZero(rawValue: number): string {
-  const formattedValue = rawValue
-    .toLocaleString(undefined, {
-      maximumFractionDigits: 3,
-    })
+  const formattedValue = rawValue.toLocaleString(undefined, {
+    maximumFractionDigits: 3,
+  })
   return formattedValue === '0' && rawValue > 0 ? '< 0.001' : formattedValue
 }
 

--- a/packages/client/src/utils/helpers/transformData.ts
+++ b/packages/client/src/utils/helpers/transformData.ts
@@ -277,9 +277,8 @@ const useFilterDataFromRecommendations = (
 function tableFormatNearZero(rawValue: number): string {
   const formattedValue = rawValue
     .toLocaleString(undefined, {
-      maximumFractionDigits: 3,
+      maximumFractionDigits: 2,
     })
-    .replace(',', '')
   return formattedValue === '0' && rawValue > 0 ? '< 0.001' : formattedValue
 }
 

--- a/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
+++ b/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
@@ -37,7 +37,8 @@ const useRemoteRecommendationsService = (
       params.footprint.data = params.footprint.data.filter((element) => {
         const elementDate = new Date(element.timestamp)
         const diffInDays = Math.ceil(
-          (currentDate.getTime() - elementDate.getTime()) / (1000 * 60 * 60 * 24),
+          (currentDate.getTime() - elementDate.getTime()) /
+            (1000 * 60 * 60 * 24),
         )
         return diffInDays <= 30
       })

--- a/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
+++ b/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
@@ -8,7 +8,7 @@ import { RecommendationResult } from '@cloud-carbon-footprint/common'
 import { ServiceResult } from '../../Types'
 import { useAxiosErrorHandling } from '../../layout/ErrorPage'
 import { FootprintData } from './FootprintDataHook'
-
+import { sliceFootprintDataByLastMonth } from '../helpers/handleDates'
 export interface UseRemoteRecommendationServiceParams {
   baseUrl: string | null
   onApiError?: (e: Error) => void
@@ -33,15 +33,9 @@ const useRemoteRecommendationsService = (
       }
       setError(null)
 
-      const currentDate = new Date()
-      params.footprint.data = params.footprint.data.filter((element) => {
-        const elementDate = new Date(element.timestamp)
-        const diffInDays = Math.ceil(
-          (currentDate.getTime() - elementDate.getTime()) /
-            (1000 * 60 * 60 * 24),
-        )
-        return diffInDays <= 30
-      })
+      params.footprint.data = sliceFootprintDataByLastMonth(
+        params.footprint.data,
+      )
 
       try {
         const res = params.awsRecommendationTarget

--- a/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
+++ b/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
@@ -8,7 +8,6 @@ import { RecommendationResult } from '@cloud-carbon-footprint/common'
 import { ServiceResult } from '../../Types'
 import { useAxiosErrorHandling } from '../../layout/ErrorPage'
 import { FootprintData } from './FootprintDataHook'
-import { sliceFootprintDataByLastMonth } from '../helpers/handleDates'
 export interface UseRemoteRecommendationServiceParams {
   baseUrl: string | null
   onApiError?: (e: Error) => void
@@ -32,10 +31,6 @@ const useRemoteRecommendationsService = (
         return
       }
       setError(null)
-
-      params.footprint.data = sliceFootprintDataByLastMonth(
-        params.footprint.data,
-      )
 
       try {
         const res = params.awsRecommendationTarget

--- a/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
+++ b/packages/client/src/utils/hooks/RecommendationsServiceHook.ts
@@ -33,6 +33,15 @@ const useRemoteRecommendationsService = (
       }
       setError(null)
 
+      const currentDate = new Date()
+      params.footprint.data = params.footprint.data.filter((element) => {
+        const elementDate = new Date(element.timestamp)
+        const diffInDays = Math.ceil(
+          (currentDate.getTime() - elementDate.getTime()) / (1000 * 60 * 60 * 24),
+        )
+        return diffInDays <= 30
+      })
+
       try {
         const res = params.awsRecommendationTarget
           ? await axios.get(`${params.baseUrl}/recommendations`, {


### PR DESCRIPTION
## Description of Change

Issue: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/1138

In the recommendations tab, there was a couple of errors.
1. Last 30 day total was showing a wrong value. Before it was the sum of every values since the date in the configuration environment file or environment variable. Now it displays the value from last 30 days as expected
2. In the recommendations table, the potential cost saving value was wrong. For instance, if the value was 1,234, it would show 1234. Now, it shows 1,234.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] yarn lint has been run

## Notes

Both @bgauchon-reply and I are working on this PR.

© 2021 Thoughtworks, Inc.
