### PR TITLE
Add unsupported usage unit of Azure - 1 GB Hour/1 GB Second

### DIFF
--- a/packages/azure/src/__tests__/ConsumptionManagement.test.ts
+++ b/packages/azure/src/__tests__/ConsumptionManagement.test.ts
@@ -540,6 +540,42 @@ describe('Azure Consumption Management Service', () => {
         periodEndDate: new Date('2020-11-02T23:59:59.000Z'),
         periodStartDate: new Date('2020-11-02T00:00:00.000Z'),
       },
+      {
+        timestamp: new Date('2020-11-04'),
+        serviceEstimates: [
+          {
+            accountId: subscriptionId,
+            accountName: subscriptionName,
+            cloudProvider: 'AZURE',
+            co2e: 5.878553215277167e-10,
+            cost: 10,
+            region: 'EastUS',
+            serviceName: 'Functions',
+            usesAverageCPUConstant: false,
+            kilowattHours: 0.0000015507871166666667,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
+          },
+          {
+            accountId: subscriptionId,
+            accountName: subscriptionName,
+            cloudProvider: 'AZURE',
+            co2e: 0.0005042891453706233,
+            cost: 7,
+            region: 'CentralUS',
+            serviceName: 'Container Instances',
+            usesAverageCPUConstant: false,
+            kilowattHours: 1.1830719368513218,
+            tags: {
+              resourceGroup: 'test-resource-group',
+            },
+          },
+        ],
+        groupBy: grouping,
+        periodEndDate: new Date('2020-11-04T23:59:59.000Z'),
+        periodStartDate: new Date('2020-11-04T00:00:00.000Z'),
+      },
     ]
     expect(result).toEqual(expectedResult)
   })

--- a/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
+++ b/packages/azure/src/__tests__/fixtures/consumptionManagement.fixtures.ts
@@ -562,6 +562,44 @@ export const mockConsumptionManagementResponseFive: UsageDetailResult[] = [
     resourceLocation: 'ukwest',
     resourceGroup: 'test-resource-group',
   },
+  {
+    id: 'test-subscription-id',
+    kind: 'legacy',
+    name: 'name',
+    type: 'type',
+    tags: {},
+
+    date: new Date('2020-11-04'),
+    quantity: 12.0185,
+    cost: 10,
+    meterDetails: {
+      meterName: 'Standard Execution Time',
+      unitOfMeasure: '1 GB Second',
+      meterCategory: 'Functions',
+    },
+    subscriptionName: 'test-subscription',
+    resourceLocation: 'EastUS',
+    resourceGroup: 'test-resource-group',
+  },
+  {
+    id: 'test-subscription-id',
+    kind: 'legacy',
+    name: 'name',
+    type: 'type',
+    tags: {},
+
+    date: new Date('2020-11-04'),
+    quantity: 2546.8697512514464,
+    cost: 7,
+    meterDetails: {
+      meterName: 'Standard Memory Duration',
+      unitOfMeasure: '1 GB Hour',
+      meterCategory: 'Container Instances',
+    },
+    subscriptionName: 'test-subscription',
+    resourceLocation: 'CentralUS',
+    resourceGroup: 'test-resource-group',
+  },
 ]
 
 export const mockConsumptionManagementResponseSix: UsageDetailResult[] = [

--- a/packages/azure/src/lib/ConsumptionManagement.ts
+++ b/packages/azure/src/lib/ConsumptionManagement.ts
@@ -495,7 +495,9 @@ export default class ConsumptionManagementService {
           powerUsageEffectiveness,
           emissionsFactors,
         )
+      case MEMORY_USAGE_UNITS.GB_SECOND_1:
       case MEMORY_USAGE_UNITS.GB_SECONDS_50000:
+      case MEMORY_USAGE_UNITS.GB_HOUR_1:
       case MEMORY_USAGE_UNITS.GB_HOURS_1000:
         return this.getMemoryFootprintEstimate(
           consumptionDetailRow,
@@ -749,8 +751,13 @@ export default class ConsumptionManagementService {
   private getUsageAmountInGigabyteHours(
     consumptionDetailRow: ConsumptionDetailRow,
   ): number {
-    if (consumptionDetailRow.usageUnit === MEMORY_USAGE_UNITS.GB_SECONDS_50000)
+    if (
+      consumptionDetailRow.usageUnit === MEMORY_USAGE_UNITS.GB_SECONDS_50000 ||
+      consumptionDetailRow.usageUnit === MEMORY_USAGE_UNITS.GB_SECOND_1
+    )
       return consumptionDetailRow.usageAmount / 3600
+    if (consumptionDetailRow.usageUnit === MEMORY_USAGE_UNITS.GB_HOUR_1)
+      return consumptionDetailRow.usageAmount
     return this.getGigabyteHoursFromInstanceTypeAndProcessors(
       consumptionDetailRow.usageType,
       consumptionDetailRow.usageAmount,

--- a/packages/azure/src/lib/ConsumptionTypes.ts
+++ b/packages/azure/src/lib/ConsumptionTypes.ts
@@ -83,7 +83,9 @@ export enum NETWORKING_USAGE_UNITS {
 }
 
 export enum MEMORY_USAGE_UNITS {
+  GB_SECOND_1 = '1 GB Second',
   GB_SECONDS_50000 = '50000 GB Seconds',
+  GB_HOUR_1 = '1 GB Hour',
   GB_HOURS_1000 = '1000 GB Hours',
 }
 


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->
To support "1 GB second" and "1GB hour" unit in [Azure ConsumptionTypes](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/packages/azure/src/lib/ConsumptionTypes.ts).

Some of business sample data like below.

resourceLocation | meterCategory | meterName | unitOfMeasure | consumedQuantity
-- | -- | -- | -- | --
EastUS | Functions | Standard Execution Time | 1 GB Second | 12.0185
CentralUS | Functions | Standard Execution Time | 1 GB Second | 180.455375
CentralUS | Functions | Standard Execution Time | 1 GB Second | 368.099625
CentralUS | Container Instances | Standard Memory Duration | 1 GB Hour | 2546.8697512514464
CentralUS | Container Instances | Standard Memory Duration | 1 GB Hour | 1488.0003837521679
CentralUS | Container Instances | Standard Memory Duration | 1 GB Hour | 0.165881712458333


fixes #1189 

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [ ] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] relevant documentation is changed or added

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
