### PR TITLE
Fix issue with concatentation of data from multiple footprint requests

### DIFF
--- a/.changeset/clean-icons-heal.md
+++ b/.changeset/clean-icons-heal.md
@@ -1,0 +1,6 @@
+---
+'@cloud-carbon-footprint/client': patch
+---
+
+Fix issue with concatentation of data from multiple footprint requests
+For changes to create-app templates, please refer to [this commit](https://github.com/mgriffin-scottlogic/cloud-carbon-footprint/commit/ff31d78ce2655469dcea2bc2afca226a4dbabb7f).

--- a/.changeset/clean-icons-heal.md
+++ b/.changeset/clean-icons-heal.md
@@ -1,6 +1,7 @@
 ---
 '@cloud-carbon-footprint/client': patch
+'@cloud-carbon-footprint/create-app': patch
 ---
 
 Fix issue with concatentation of data from multiple footprint requests
-For changes to create-app templates, please refer to [this commit](https://github.com/mgriffin-scottlogic/cloud-carbon-footprint/commit/ff31d78ce2655469dcea2bc2afca226a4dbabb7f).
+For changes to create-app templates, please refer to [this commit](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/pull/1194/commits/65f76245d4947cd0bb1b7e4a5b761868dd9c6da0).

--- a/packages/client/src/utils/hooks/FootprintServiceHook.test.ts
+++ b/packages/client/src/utils/hooks/FootprintServiceHook.test.ts
@@ -293,6 +293,10 @@ describe('FootprintServiceHook', () => {
         loading: false,
         error: null,
       })
+      expect(result.current.data[0].serviceEstimates.length).toEqual(2)
+      expect(result.current.data[0].serviceEstimates[1]).toEqual(
+        mockEstimateTwo.serviceEstimates[0],
+      )
     })
   })
 })

--- a/packages/client/src/utils/hooks/FootprintServiceHook.ts
+++ b/packages/client/src/utils/hooks/FootprintServiceHook.ts
@@ -123,7 +123,7 @@ const concatenateResults = (estimates, newEstimates) => {
     )
 
     if (newDateExists) {
-      const elementIndex = updatedEstimates.find((estimate) =>
+      const elementIndex = updatedEstimates.findIndex((estimate) =>
         moment
           .utc(estimate.timestamp)
           .isSame(moment.utc(newEstimate.timestamp)),

--- a/packages/create-app/templates/default-app/packages/client/src/utils/hooks/FootprintServiceHook.ts
+++ b/packages/create-app/templates/default-app/packages/client/src/utils/hooks/FootprintServiceHook.ts
@@ -123,7 +123,7 @@ const concatenateResults = (estimates, newEstimates) => {
     )
 
     if (newDateExists) {
-      const elementIndex = updatedEstimates.find((estimate) =>
+      const elementIndex = updatedEstimates.findIndex((estimate) =>
         moment
           .utc(estimate.timestamp)
           .isSame(moment.utc(newEstimate.timestamp)),


### PR DESCRIPTION
## Fix issue with concatentation of data from multiple footprint requests

fixes #1193 - Use of find() instead of findIndex() meant that search for existing estimate always returned `undefined`.
@4upz 
 
## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [ ] yarn test passes
- [x] yarn lint has been run
- [ ] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)

## Notes

Committed using --no-verify but only test that failed locally was in unchanged packages/cli folder.
