### PR TITLE
feat: add subscriptionIds as a param to azure account

### DIFF
--- a/.changeset/six-poems-compete.md
+++ b/.changeset/six-poems-compete.md
@@ -1,0 +1,6 @@
+---
+'@cloud-carbon-footprint/app': minor
+'@cloud-carbon-footprint/azure': minor
+---
+
+Add subscriptionIds as a parameter to getDataFromConsumptionManagement

--- a/packages/app/src/App.ts
+++ b/packages/app/src/App.ts
@@ -43,7 +43,7 @@ export default class App {
     request: EstimationRequest,
   ): Promise<EstimationResult[]> {
     const appLogger = new Logger('App')
-    const { startDate, endDate, cloudProviderToSeed } = request
+    const { startDate, endDate, accounts, cloudProviderToSeed } = request
     const grouping = request.groupBy as GroupBy
     const config = configLoader()
     includeCloudProviders(cloudProviderToSeed, config)
@@ -115,6 +115,7 @@ export default class App {
         startDate,
         endDate,
         grouping,
+        accounts,
       )
       AzureEstimatesByRegion.push(estimates)
       appLogger.info('Finished Azure Estimations')

--- a/packages/azure/src/__tests__/AzureAccount.test.ts
+++ b/packages/azure/src/__tests__/AzureAccount.test.ts
@@ -59,7 +59,7 @@ describe('Azure Account', () => {
         secret: 'test-client-secret',
         domain: 'test-tenant-id',
       }
-      ;(createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+        ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
 
       mockListSubscriptions.list.mockReturnValue([
         { subscriptionId: 'sub-1' },
@@ -88,7 +88,7 @@ describe('Azure Account', () => {
         },
       ]
 
-      ;(getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
+        ; (getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
 
       const promiseSpy = jest.spyOn(Promise, 'all')
 
@@ -160,7 +160,7 @@ describe('Azure Account', () => {
           secret: 'test-client-secret',
           domain: 'test-tenant-id',
         }
-        ;(createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+          ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
         mockListSubscriptions.list.mockReturnValue([
           { subscriptionId: 'sub-1' },
           { subscriptionId: 'sub-2' },
@@ -191,7 +191,7 @@ describe('Azure Account', () => {
           },
         ]
 
-        ;(getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
+          ; (getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
 
         const AZURE = configLoader().AZURE || {}
         AZURE.SUBSCRIPTION_CHUNKS = 2
@@ -222,13 +222,13 @@ describe('Azure Account', () => {
         delete AZURE.SUBSCRIPTION_CHUNKS
       })
 
-      it('fetches data only for specific subscriptions when specified subscriptions are set', async () => {
+      it('fetches data only for specific subscriptions when specified environment variable subscriptions are set', async () => {
         const mockCredentials = {
           clientId: 'test-client-id',
           secret: 'test-client-secret',
           domain: 'test-tenant-id',
         }
-        ;(createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+          ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
 
         const AZURE: any = configLoader().AZURE || {}
         const subscriptions = ['sub-1', 'sub-2', 'sub-3']
@@ -260,7 +260,7 @@ describe('Azure Account', () => {
           },
         ]
 
-        ;(getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
+          ; (getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
         const getDataForSubscriptionSpy = jest.spyOn(
           AzureAccount.prototype,
           'getDataForSubscription',
@@ -295,6 +295,76 @@ describe('Azure Account', () => {
         // Reset the config
         delete AZURE.SUBSCRIPTIONS
       })
+
+      it('fetches data only for specific subscriptions when specified parameter subscriptions are set', async () => {
+        const mockCredentials = {
+          clientId: 'test-client-id',
+          secret: 'test-client-secret',
+          domain: 'test-tenant-id',
+        }
+          ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+
+        const subscriptions = ['sub-1', 'sub-2', 'sub-3']
+
+        subscriptions.forEach((subscriptionId) => {
+          mockListSubscriptions.get.mockReturnValueOnce({ subscriptionId })
+        })
+
+        const mockEstimates: EstimationResult[] = [
+          {
+            timestamp: startDate,
+            serviceEstimates: [
+              {
+                kilowattHours: 0.09313874999999999,
+                co2e: 0.000021235635,
+                usesAverageCPUConstant: true,
+                cloudProvider: 'AZURE',
+                accountId: testAccountId,
+                accountName: testAccountName,
+                serviceName: 'Virtual Machines',
+                cost: 5,
+                region: 'UK South',
+              },
+            ],
+            periodStartDate: startDate,
+            periodEndDate: endDate,
+            groupBy: grouping,
+          },
+        ]
+
+          ; (getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
+        const getDataForSubscriptionSpy = jest.spyOn(
+          AzureAccount.prototype,
+          'getDataForSubscription',
+        )
+
+        // when
+        const azureAccount = new AzureAccount()
+        await azureAccount.initializeAccount()
+        const results = await azureAccount.getDataFromConsumptionManagement(
+          startDate,
+          endDate,
+          grouping,
+          subscriptions,
+        )
+
+        // Results should be the same as the mockEstimates array repeated35 times
+        const expectedEstimates = Array.from(
+          { length: 3 },
+          () => mockEstimates[0],
+        )
+
+        expect(results).toEqual(expectedEstimates)
+        // getDataForSubscription should have been called 3 times (once for each given subscription ID)
+        subscriptions.forEach((subscriptionId) => {
+          expect(getDataForSubscriptionSpy).toHaveBeenCalledWith(
+            startDate,
+            endDate,
+            subscriptionId,
+            grouping,
+          )
+        })
+      })
     })
   })
 
@@ -304,7 +374,7 @@ describe('Azure Account', () => {
       secret: 'test-client-secret',
       domain: 'test-tenant-id',
     }
-    ;(createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+      ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
 
     mockListSubscriptions.list.mockReturnValue([
       { subscriptionId: 'sub-1' },
@@ -328,7 +398,7 @@ describe('Azure Account', () => {
       },
     ]
 
-    ;(getRecommendationsSpy as jest.Mock).mockResolvedValue(mockRecommendations)
+      ; (getRecommendationsSpy as jest.Mock).mockResolvedValue(mockRecommendations)
 
     // when
     const azureAccount = new AzureAccount()
@@ -403,7 +473,7 @@ describe('Azure Account', () => {
     const errorMessage = 'Some error'
     const apiError = new Error(errorMessage)
 
-    ;(createCredentialsSpy as jest.Mock).mockRejectedValue(apiError)
+      ; (createCredentialsSpy as jest.Mock).mockRejectedValue(apiError)
 
     const azureAccount = new AzureAccount()
 

--- a/packages/azure/src/__tests__/AzureAccount.test.ts
+++ b/packages/azure/src/__tests__/AzureAccount.test.ts
@@ -59,7 +59,7 @@ describe('Azure Account', () => {
         secret: 'test-client-secret',
         domain: 'test-tenant-id',
       }
-        ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+      ;(createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
 
       mockListSubscriptions.list.mockReturnValue([
         { subscriptionId: 'sub-1' },
@@ -88,7 +88,7 @@ describe('Azure Account', () => {
         },
       ]
 
-        ; (getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
+      ;(getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
 
       const promiseSpy = jest.spyOn(Promise, 'all')
 
@@ -160,7 +160,7 @@ describe('Azure Account', () => {
           secret: 'test-client-secret',
           domain: 'test-tenant-id',
         }
-          ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+        ;(createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
         mockListSubscriptions.list.mockReturnValue([
           { subscriptionId: 'sub-1' },
           { subscriptionId: 'sub-2' },
@@ -191,7 +191,7 @@ describe('Azure Account', () => {
           },
         ]
 
-          ; (getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
+        ;(getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
 
         const AZURE = configLoader().AZURE || {}
         AZURE.SUBSCRIPTION_CHUNKS = 2
@@ -228,7 +228,7 @@ describe('Azure Account', () => {
           secret: 'test-client-secret',
           domain: 'test-tenant-id',
         }
-          ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+        ;(createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
 
         const AZURE: any = configLoader().AZURE || {}
         const subscriptions = ['sub-1', 'sub-2', 'sub-3']
@@ -260,7 +260,7 @@ describe('Azure Account', () => {
           },
         ]
 
-          ; (getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
+        ;(getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
         const getDataForSubscriptionSpy = jest.spyOn(
           AzureAccount.prototype,
           'getDataForSubscription',
@@ -302,7 +302,7 @@ describe('Azure Account', () => {
           secret: 'test-client-secret',
           domain: 'test-tenant-id',
         }
-          ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+        ;(createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
 
         const subscriptions = ['sub-1', 'sub-2', 'sub-3']
 
@@ -332,7 +332,7 @@ describe('Azure Account', () => {
           },
         ]
 
-          ; (getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
+        ;(getEstimatesSpy as jest.Mock).mockResolvedValue(mockEstimates)
         const getDataForSubscriptionSpy = jest.spyOn(
           AzureAccount.prototype,
           'getDataForSubscription',
@@ -374,7 +374,7 @@ describe('Azure Account', () => {
       secret: 'test-client-secret',
       domain: 'test-tenant-id',
     }
-      ; (createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
+    ;(createCredentialsSpy as jest.Mock).mockResolvedValue(mockCredentials)
 
     mockListSubscriptions.list.mockReturnValue([
       { subscriptionId: 'sub-1' },
@@ -398,7 +398,7 @@ describe('Azure Account', () => {
       },
     ]
 
-      ; (getRecommendationsSpy as jest.Mock).mockResolvedValue(mockRecommendations)
+    ;(getRecommendationsSpy as jest.Mock).mockResolvedValue(mockRecommendations)
 
     // when
     const azureAccount = new AzureAccount()
@@ -473,7 +473,7 @@ describe('Azure Account', () => {
     const errorMessage = 'Some error'
     const apiError = new Error(errorMessage)
 
-      ; (createCredentialsSpy as jest.Mock).mockRejectedValue(apiError)
+    ;(createCredentialsSpy as jest.Mock).mockRejectedValue(apiError)
 
     const azureAccount = new AzureAccount()
 

--- a/packages/azure/src/application/AzureAccount.ts
+++ b/packages/azure/src/application/AzureAccount.ts
@@ -80,11 +80,15 @@ export default class AzureAccount extends CloudProviderAccount {
     startDate: Date,
     endDate: Date,
     grouping: GroupBy,
+    subscriptionIds: string[] = [],
   ): Promise<EstimationResult[]> {
     const AZURE = configLoader().AZURE
+    const defaultAzureSubscriptionIds = subscriptionIds.length
+      ? subscriptionIds
+      : AZURE.SUBSCRIPTIONS
 
-    const subscriptions = AZURE.SUBSCRIPTIONS?.length
-      ? await this.getSubscriptionsByIds(AZURE.SUBSCRIPTIONS)
+    const subscriptions = defaultAzureSubscriptionIds?.length
+      ? await this.getSubscriptionsByIds(defaultAzureSubscriptionIds)
       : await this.getSubscriptions()
 
     const requests = this.createSubscriptionRequests(
@@ -120,8 +124,7 @@ export default class AzureAccount extends CloudProviderAccount {
 
     if (subscriptions.length === 0) {
       this.logger.warn(
-        'No subscription returned for these Azure credentials, be sure the registered application has ' +
-          'enough permissions. Go to https://www.cloudcarbonfootprint.org/docs/azure/ for more information.',
+        `No subscription returned for these Azure credentials, be sure the registered application has enough permissions. Go to https://www.cloudcarbonfootprint.org/docs/azure/ for more information.`,
       )
     }
 

--- a/packages/azure/src/application/AzureAccount.ts
+++ b/packages/azure/src/application/AzureAccount.ts
@@ -124,7 +124,8 @@ export default class AzureAccount extends CloudProviderAccount {
 
     if (subscriptions.length === 0) {
       this.logger.warn(
-        `No subscription returned for these Azure credentials, be sure the registered application has enough permissions. Go to https://www.cloudcarbonfootprint.org/docs/azure/ for more information.`,
+        'No subscription returned for these Azure credentials, be sure the registered application has ' +
+          'enough permissions. Go to https://www.cloudcarbonfootprint.org/docs/azure/ for more information.',
       )
     }
 


### PR DESCRIPTION
## Description of Change

We want to get Azure Subscriptions on the fly, not via MongoDB cache (we use our own DB for caching aggregated data), currently we can't do this because azure subscriptions are only available via an ENV variable. They should be from the `accounts` param too.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [] yarn lint has been run -> This has tons of prettier errors in my terminal unrelated?
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
