### PR TITLE
feat: add subscriptionids to recommendations

### DIFF
--- a/.changeset/fair-rivers-shave.md
+++ b/.changeset/fair-rivers-shave.md
@@ -1,0 +1,6 @@
+---
+'@cloud-carbon-footprint/app': minor
+'@cloud-carbon-footprint/azure': minor
+---
+
+Add subscriptionIds to /recommendations API so that we can get recommendations per account as a param, not just from an env variable

--- a/.changeset/fair-rivers-shave.md
+++ b/.changeset/fair-rivers-shave.md
@@ -3,4 +3,4 @@
 '@cloud-carbon-footprint/azure': minor
 ---
 
-Add subscriptionIds to /recommendations API so that we can get recommendations per account as a param, not just from an env variable
+Add subscriptionIds to /recommendations API for azure accounts so that we can get recommendations per account as a param, not just from an env variable

--- a/packages/app/src/App.ts
+++ b/packages/app/src/App.ts
@@ -230,7 +230,9 @@ export default class App {
     if (AZURE?.USE_BILLING_DATA) {
       const azureAccount = new AzureAccount()
       await azureAccount.initializeAccount()
-      const recommendations = await azureAccount.getDataFromAdvisorManagement()
+      const recommendations = await azureAccount.getDataFromAdvisorManagement(
+        request.accounts,
+      )
       AzureRecommendations.push(recommendations)
     }
     allRecommendations.push(AzureRecommendations.flat())

--- a/packages/app/src/CreateValidRequest.ts
+++ b/packages/app/src/CreateValidRequest.ts
@@ -33,6 +33,7 @@ export interface EstimationRequest {
 
 export interface RecommendationRequest {
   awsRecommendationTarget?: AWS_RECOMMENDATIONS_TARGETS
+  accounts?: string[]
 }
 
 interface FormattedEstimationRequest {

--- a/packages/app/src/RawRequest.ts
+++ b/packages/app/src/RawRequest.ts
@@ -19,6 +19,7 @@ export interface FootprintEstimatesRawRequest {
 
 export interface RecommendationsRawRequest {
   awsRecommendationTarget?: string
+  accounts?: string[]
 }
 
 export interface Tags {

--- a/packages/app/src/__tests__/App.test.ts
+++ b/packages/app/src/__tests__/App.test.ts
@@ -1285,6 +1285,43 @@ describe('App', () => {
 
       expect(result).toEqual(expectedRecommendations)
     })
+
+    it('returns recommendations for azure with billing data for only the specified subscriptions', async () => {
+      ;(configLoader as jest.Mock).mockReturnValue({
+        ...configLoader(),
+        AZURE: {
+          ...configLoader().AZURE,
+          USE_BILLING_DATA: true,
+        },
+      })
+
+      const expectedRecommendations: RecommendationResult[] = [
+        {
+          cloudProvider: 'AZURE',
+          accountId: 'account-id-2',
+          accountName: 'account-name',
+          region: 'useast',
+          recommendationType: 'Shutdown',
+          recommendationDetail: 'Shutdown instance: test-vm-name.',
+          kilowattHourSavings: 5,
+          co2eSavings: 20,
+          costSavings: 3,
+        },
+      ]
+
+      const newDefaultRequest = {
+        ...defaultRequest,
+        accounts: ['account-id-2'],
+      }
+
+      getDataForAWSRecommendations.mockResolvedValue([])
+      getDataForGCPRecommendations.mockResolvedValue([])
+      getDataForAzureRecommendations.mockResolvedValue(expectedRecommendations)
+      initializeAzureAccount.mockResolvedValue()
+      const result = await app.getRecommendations(newDefaultRequest)
+
+      expect(result).toEqual(expectedRecommendations)
+    })
   })
 })
 


### PR DESCRIPTION
## Description of Change

- Add subscriptionIds to /recommendations API so that we can get recommendations per account as a param, not just from an env variable

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are changed or added
- [x] yarn test passes
- [x] yarn lint has been run
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
