### PR TITLE
fix: add region options for Australia East, Australia South East and …

### DIFF
--- a/packages/azure/src/lib/AzureRegions.ts
+++ b/packages/azure/src/lib/AzureRegions.ts
@@ -28,10 +28,13 @@ export const AZURE_REGIONS = {
     name: 'australiacentral2',
     options: ['australiacentral2'],
   },
-  AP_AUSTRALIA_EAST: { name: 'australiaeast', options: ['australiaeast'] },
+  AP_AUSTRALIA_EAST: {
+    name: 'australiaeast',
+    options: ['australiaeast', 'AustraliaEast', 'AUSTRALIAEAST'],
+  },
   AP_AUSTRALIA_SOUTH_EAST: {
     name: 'australiasoutheast',
-    options: ['australiasoutheast'],
+    options: ['australiasoutheast', 'AustraliaSouthEast', 'AUSTRALIASOUTHEAST'],
   },
   AP_EAST: { name: 'apeast', options: ['apeast', 'AP East'] },
   AP_SOUTH_EAST: {
@@ -53,7 +56,12 @@ export const AZURE_REGIONS = {
   ASIA_EAST_STAGE: { name: 'eastasiastage', options: ['eastasiastage'] },
   ASIA_SOUTH_EAST: {
     name: 'southeastasia',
-    options: ['southeastasia', 'AsiaSouthEast', 'asiasoutheast'],
+    options: [
+      'southeastasia',
+      'AsiaSouthEast',
+      'asiasoutheast',
+      'SOUTHEASTASIA',
+    ],
   },
   ASIA_SOUTH_EAST_STAGE: {
     name: 'southeastasiastage',


### PR DESCRIPTION
…Asia South East to AzureRegions.ts

## Description of Change

I've reviewed the combined.log file and I've noticed that a few regions generated a warning 'Australia East', 'Australia South East', 'Asia South East', and as it was recommended in the logs, I'm raising a PR for fixing the issue.

I've pasted an example below
```
[AzureRegions] warn: Found unknown azure region 'AUSTRALIAEAST', please add it to the AzureRegions.ts file and submit a PR, thank you!
```

## Checklist

- [x] PR description included and stakeholders cc'd
- [x] yarn test passes
- [x] yarn lint has been run

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
