### PR TITLE
Add support for auth with Azure using an SPN and a certificate

### DIFF
--- a/.changeset/ninety-paws-march.md
+++ b/.changeset/ninety-paws-march.md
@@ -1,0 +1,6 @@
+---
+'@cloud-carbon-footprint/azure': minor
+'@cloud-carbon-footprint/common': minor
+---
+
+Add support for authenticating with Azure using an SPN and a cetificate instead of a client secret

--- a/microsite/docs/ConnectingData/Azure.md
+++ b/microsite/docs/ConnectingData/Azure.md
@@ -69,4 +69,6 @@ By default, the application authenticates with Azure using environment variables
 
 The authentication mode is set inside [packages/common/src/Config.ts](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/packages/common/src/Config.ts), and you can see these options being used in [packages/azure/src/application/AzureCredentialsProvider.ts](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/packages/azure/src/application/AzureCredentialsProvider.ts).
 
+To establish authentication with Azure using a Service Principal (SPN) and a certificate, the initial steps involve creating them in Azure as outlined in [this guide](https://learn.microsoft.com/en-us/cli/azure/azure-cli-sp-tutorial-1?tabs=bash). Additionally, ensure that the AZURE_AUTH_MODE is configured to "CERTIFICATE" and AZURE_CERTIFICATE_PATH is set to path of your certificate to enable SPN-based authentication.
+
 <!-- © 2021 Thoughtworks, Inc. -->

--- a/packages/azure/src/application/AzureAccount.ts
+++ b/packages/azure/src/application/AzureAccount.ts
@@ -7,6 +7,7 @@ import {
   Subscription,
 } from '@azure/arm-resources-subscriptions'
 import {
+  ClientCertificateCredential,
   ClientSecretCredential,
   WorkloadIdentityCredential,
 } from '@azure/identity'
@@ -38,7 +39,10 @@ import AdvisorRecommendations from '../lib/AdvisorRecommendations'
 import { AZURE_CLOUD_CONSTANTS } from '../domain'
 
 export default class AzureAccount extends CloudProviderAccount {
-  private credentials: ClientSecretCredential | WorkloadIdentityCredential
+  private credentials:
+    | ClientCertificateCredential
+    | ClientSecretCredential
+    | WorkloadIdentityCredential
   private subscriptionClient: SubscriptionClient
   private logger: Logger
 

--- a/packages/azure/src/application/AzureCredentialsProvider.ts
+++ b/packages/azure/src/application/AzureCredentialsProvider.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  ClientCertificateCredential,
   ClientSecretCredential,
   WorkloadIdentityCredential,
 } from '@azure/identity'
@@ -12,11 +13,14 @@ import { configLoader } from '@cloud-carbon-footprint/common'
 
 export default class AzureCredentialsProvider {
   static async create(): Promise<
-    ClientSecretCredential | WorkloadIdentityCredential
+    | ClientCertificateCredential
+    | ClientSecretCredential
+    | WorkloadIdentityCredential
   > {
     const clientId = configLoader().AZURE.authentication.clientId
     const clientSecret = configLoader().AZURE.authentication.clientSecret
     const tenantId = configLoader().AZURE.authentication.tenantId
+    const certificatePath = configLoader().AZURE.authentication.certificatePath
 
     switch (configLoader().AZURE.authentication.mode) {
       case 'GCP':
@@ -33,6 +37,12 @@ export default class AzureCredentialsProvider {
           tenantId: tenantId,
           clientId: clientId,
         })
+      case 'CERTIFICATE':
+        return new ClientCertificateCredential(
+          tenantId,
+          clientId,
+          certificatePath,
+        )
       default:
         return new ClientSecretCredential(tenantId, clientId, clientSecret)
     }

--- a/packages/common/src/Config.ts
+++ b/packages/common/src/Config.ts
@@ -56,6 +56,7 @@ export interface CCFConfig {
       mode: string
       clientId?: string
       clientSecret?: string
+      certificatePath?: string
       tenantId?: string
     }
     RESOURCE_TAG_NAMES?: string[]
@@ -269,6 +270,7 @@ const getConfig = (): CCFConfig => ({
       mode: getEnvVar('AZURE_AUTH_MODE') || 'default',
       clientId: getEnvVar('AZURE_CLIENT_ID') || '',
       clientSecret: getEnvVar('AZURE_CLIENT_SECRET') || '',
+      certificatePath: getEnvVar('AZURE_CERTIFICATE_PATH') || '',
       tenantId: getEnvVar('AZURE_TENANT_ID') || '',
     },
     RESOURCE_TAG_NAMES: JSON.parse(getAzureResourceTagNames()),


### PR DESCRIPTION
## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->
Adds support for authentication with Azure using an SPN and a certificate. This fixes #1269.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
- [x] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
