### PR TITLE
Trivial documentation fix: remove 'region' as arg for the CLI

### DIFF
--- a/microsite/docs/GettingStarted/RunningTheCli.md
+++ b/microsite/docs/GettingStarted/RunningTheCli.md
@@ -19,6 +19,5 @@ Or you can choose to pass the parameters in a single line:
 
     --startDate YYYY-MM-DD \
     --endDate YYYY-MM-DD \
-    --region [us-east-1 | us-east-2] \
     --groupBy [day | dayAndService | service] \
     --format [table | csv]


### PR DESCRIPTION
The website still mentions `region` but it has been removed since 1.10.0 via 003c8892