### PR TITLE
#1322 add support for hardened container environments

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,9 +1,10 @@
 events {
 }
+pid /tmp/nginx.pid;
 
 http {
     server {
-        listen 80;
+        listen 8080;
         include /etc/nginx/mime.types;
         root /var/www;
         index index.html index.htm;

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -5,6 +5,6 @@ COPY ./build /app/build
 
 RUN yarn install --immutable
 
-FROM nginx:stable-alpine
+FROM nginxinc/nginx-unprivileged:1.25
 COPY --from=build /app/build /var/www
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Description of Change

This change hardens the container to use nginxinc/nginx-unprivileged:1.25 container for getting the container up and running in a hardened enviroment, where privileged containers are not allowed or capabilities are restricted.

https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/1322

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] yarn test passes
- [x] yarn lint has been run
- [x] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)

## Notes

This applies for the frontend (client) application only. Configuration changes for the helm templates are not included.

© 2021 Thoughtworks, Inc.
