### PR TITLE
Update node ccf-compute-optimizer.yaml

### DIFF
--- a/cloudformation/ccf-compute-optimizer.yaml
+++ b/cloudformation/ccf-compute-optimizer.yaml
@@ -201,7 +201,7 @@ Resources:
   relocateFunction:
     Type: AWS::Lambda::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       Timeout: 300
       Role: !GetAtt LambdaExecutionRole.Arn
       Handler: index.handler


### PR DESCRIPTION
AWS no longer supports node 14, I tested it with version 20 and it's ok

## Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/blob/trunk/CONTRIBUTING.md
-->

Write a brief but concise description of the changes you have made while also making sure to **link the relevant issue number to this PR** _( e.g. fixes #ISSUE-NUMBER - optional short description)_

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] tests are changed or added
- [ ] yarn test passes
- [ ] yarn lint has been run
- [ ] git pre-commit hook is successfully executed.
      (**Please refrain from using `--no-verify`**)
- [ ] yarn changeset was run and relevant packages have been updated as a major/minor/patch bump with descriptions
      (**Determine version update using [Semantic Versioning](https://semver.org/)**)
- [ ] relevant documentation is changed or added

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
