### PR TITLE
Fix create Lookup Table

### DIFF
--- a/packages/aws/src/lib/CostAndUsageReports.ts
+++ b/packages/aws/src/lib/CostAndUsageReports.ts
@@ -395,7 +395,6 @@ export default class CostAndUsageReports {
       timestamp: rowData.timestamp,
       cost: rowData.cost,
       usageUnit: rowData.usageUnit,
-      usageType: rowData.usageType,
     }
     const unknownConstants: CloudConstants = {
       kilowattHoursByServiceAndUsageUnit:

--- a/packages/aws/src/lib/CostAndUsageReports.ts
+++ b/packages/aws/src/lib/CostAndUsageReports.ts
@@ -194,8 +194,8 @@ export default class CostAndUsageReports {
         inputDataRow.usageType,
         inputDataRow.usageUnit,
         inputDataRow.vCpus != '' ? parseFloat(inputDataRow.vCpus) : null,
-        1,
-        1,
+        parseFloat(inputDataRow.usageAmount || '1') || 1,
+        parseFloat(inputDataRow.cost || '1') || 1,
         {},
       )
       const dateTime = new Date().toISOString()
@@ -221,8 +221,11 @@ export default class CostAndUsageReports {
           region: inputDataRow.region,
           usageType: inputDataRow.usageType,
           vCpus: inputDataRow.vCpus,
-          kilowattHours: footprintEstimate.kilowattHours,
-          co2e: footprintEstimate.co2e,
+          kilowattHours:
+            (footprintEstimate.kilowattHours || 0) /
+            costAndUsageReportRow.usageAmount,
+          co2e:
+            (footprintEstimate.co2e || 0) / costAndUsageReportRow.usageAmount,
         })
       }
     }
@@ -236,8 +239,9 @@ export default class CostAndUsageReports {
             region: inputDataRow.region,
             usageType: inputDataRow.usageType,
             vCpus: inputDataRow.vCpus,
-            kilowattHours: footprintEstimate.kilowattHours,
-            co2e: footprintEstimate.co2e,
+            kilowattHours:
+              (footprintEstimate.kilowattHours || 0) / inputDataRow.usageAmount,
+            co2e: (footprintEstimate.co2e || 0) / inputDataRow.usageAmount,
           })
       })
     }
@@ -391,6 +395,7 @@ export default class CostAndUsageReports {
       timestamp: rowData.timestamp,
       cost: rowData.cost,
       usageUnit: rowData.usageUnit,
+      usageType: rowData.usageType,
     }
     const unknownConstants: CloudConstants = {
       kilowattHoursByServiceAndUsageUnit:

--- a/packages/aws/src/lib/CostAndUsageReports.ts
+++ b/packages/aws/src/lib/CostAndUsageReports.ts
@@ -194,8 +194,8 @@ export default class CostAndUsageReports {
         inputDataRow.usageType,
         inputDataRow.usageUnit,
         inputDataRow.vCpus != '' ? parseFloat(inputDataRow.vCpus) : null,
-        parseFloat(inputDataRow.usageAmount || '1') || 1,
-        parseFloat(inputDataRow.cost || '1') || 1,
+        parseFloat(inputDataRow.usageAmount?.toString() || '1'),
+        parseFloat(inputDataRow.cost.toString() || '1'),
         {},
       )
       const dateTime = new Date().toISOString()

--- a/packages/aws/src/lib/CostAndUsageReports.ts
+++ b/packages/aws/src/lib/CostAndUsageReports.ts
@@ -195,7 +195,7 @@ export default class CostAndUsageReports {
         inputDataRow.usageUnit,
         inputDataRow.vCpus != '' ? parseFloat(inputDataRow.vCpus) : null,
         parseFloat(inputDataRow.usageAmount?.toString() || '1'),
-        parseFloat(inputDataRow.cost.toString() || '1'),
+        parseFloat(inputDataRow.cost?.toString() || '1'),
         {},
       )
       const dateTime = new Date().toISOString()

--- a/packages/common/src/LookupTableInput.ts
+++ b/packages/common/src/LookupTableInput.ts
@@ -9,6 +9,8 @@ export type LookupTableInput = {
   usageUnit: string
   vCpus?: string
   machineType?: string
+  usageAmount?: string
+  cost?: string
 }
 
 export type LookupTableOutput = {

--- a/packages/common/src/LookupTableInput.ts
+++ b/packages/common/src/LookupTableInput.ts
@@ -9,8 +9,8 @@ export type LookupTableInput = {
   usageUnit: string
   vCpus?: string
   machineType?: string
-  usageAmount?: string
-  cost?: string
+  usageAmount?: string | number
+  cost?: string | number
 }
 
 export type LookupTableOutput = {

--- a/packages/core/src/FootprintEstimate.ts
+++ b/packages/core/src/FootprintEstimate.ts
@@ -181,14 +181,14 @@ export const appendOrAccumulateEstimatesByDay = (
 ): void => {
   const serviceEstimate: MutableServiceEstimate = {
     cloudProvider: rowData.cloudProvider,
-    kilowattHours: footprintEstimate.kilowattHours,
-    co2e: footprintEstimate.co2e,
+    kilowattHours: footprintEstimate.kilowattHours || 0,
+    co2e: footprintEstimate.co2e || 0,
     usesAverageCPUConstant: !!footprintEstimate?.usesAverageCPUConstant,
     serviceName: rowData.serviceName,
     accountId: rowData.accountId,
     accountName: rowData.accountName,
     region: rowData.region,
-    cost: rowData.cost,
+    cost: rowData.cost || 0,
     tags: rowData.tags,
   }
 


### PR DESCRIPTION
## Fix Create Lookup table with incorrect estimation on 1 unit of usage amount
Issue: when I create a Lookup table based on input usage csv, but after multiply value on usage csv with estimation value on Lookup table. It didn't match the value from API `/footprint`

Maybe this is something like the issue on [ISSUE-839](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/issues/839)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] yarn test passes
- [x] yarn lint has been run

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
