### PR TITLE
Fix docker port mapping of client

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -4,7 +4,7 @@ services:
   client:
     build: packages/client
     ports:
-      - '80:80'
+      - '80:8080'
     volumes:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   client:
     image: cloudcarbonfootprint/client:latest
     ports:
-      - '80:80'
+      - '80:8080'
     volumes:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf
     depends_on:

--- a/microsite/docs/GettingStarted/RunWithDocker.md
+++ b/microsite/docs/GettingStarted/RunWithDocker.md
@@ -50,7 +50,7 @@ If you would like to run the client as a docker container, you can pull and run 
     docker pull cloudcarbonfootprint/client:latest
 
     docker run \
-        -p 80:80 \
+        -p 80:8080 \
         -v ${PWD}/docker/nginx.conf:/etc/nginx/nginx.conf \
         cloudcarbonfootprint/client:latest
 


### PR DESCRIPTION
## Description of Change

The port of the client was changed in #1322 from 80 to 8080, however, it was not changed in the docker compose files and in the documentation.

## Checklist

- [x] git pre-commit hook is successfully executed.
- [x] relevant documentation is changed or added

## Notes

Additional information relevant to the changes

© 2021 Thoughtworks, Inc.
