### PR TITLE
Fix compatibility issues with script branch_warning.sh

### DIFF
--- a/scripts/branch_warning.sh
+++ b/scripts/branch_warning.sh
@@ -9,14 +9,15 @@ branch="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$branch" != "trunk" ]; then
     if [ -t 1 ]; then
         # We're running interactive
-        read -p "Are you sure you want to use a branch that isn't trunk? (y/n): " -n 1 -r < /dev/tty
+        echo "Are you sure you want to use a branch that isn't trunk? (y/n): \c"
+        read REPLY < /dev/tty
     else
         # We're running non-interactive (possibly called by IDE)
         echo "This is not the trunk branch and we assume that's intended."
         REPLY="Y"
     fi
     echo
-    if [ $REPLY =~ ^[Yy]$ ]; then
+    if [ "$REPLY" = "Y" ] || [ "$REPLY" = "y" ]; then
         echo "Okie dokie. Be Careful out there :)"
         exit 0
     fi


### PR DESCRIPTION
## Description of Change

The shell script `branch_warning.sh` had compatibility issues because it uses Bash specific syntax.

Errors:

```
./scripts/branch_warning.sh: 12: read: Illegal option -n

./scripts/branch_warning.sh: 19: [: =~: unexpected operator
```

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] git pre-commit hook is successfully executed.

## Notes

© 2021 Thoughtworks, Inc.
